### PR TITLE
Fix jest reporter

### DIFF
--- a/lib/adapter/jest.js
+++ b/lib/adapter/jest.js
@@ -26,7 +26,13 @@ class JestReporter {
         error = failureMessages[0].replace(ansiRegExp(), '');
       }
       const testId = parseTest(title);
-      this.client.addTestRun(testId, status, error, title, duration);
+      const deducedStatus = status === 'pending' ? 'skipped' : status;
+
+      // In jest if test is not matched with test name pattern it is considered as skipped.
+      // So adding a check if it is skipped for real or because of test pattern
+      if (!this._globalConfig.testNamePattern || deducedStatus !== 'skipped') {
+        this.client.addTestRun(testId, deducedStatus, error, title, duration);
+      }
     }
   }
 


### PR DESCRIPTION
Fixed
Skipped jest tests are shown as failed in testomat reporting #76
 On analysis found 2 problems

1. Skipped tests are marked as pending by jest but server can understand skipped only
I2. n jest if pattern is used all other test are marked as pending. Need to add a check if grep is used or not to publish the test that are actually skipped and not because of grep