### PR TITLE
feat: display the report url properly

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -58,7 +58,7 @@ class TestomatClient {
           .post(`${TESTOMAT_URL.trim()}/api/reporter`, runParams)
           .then((resp) => {
             this.runId = resp.data.uid;
-            this.runUrl = resp.data.url;
+            this.runUrl = `${TESTOMAT_URL}/${resp.data.url.split('/').splice(3).join('/')}`;
             console.log(
               APP_PREFIX,
               "📊 Report created. Report ID:",


### PR DESCRIPTION
There is such a case when using the on-premise setup and `TESTOMAT_URL` is not always localhost so this PR aims to improve this report url.

After:
```
  OK  | 1 passed   // 333ms
[TESTOMATIO] 📊 Report Saved. Report URL: http://testomatio.yourdomain:port/projects/automation-api/runs/d5474e6a/report

```