### PR TITLE
New CSV pipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ dist
 
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
+
+#Export files folder
+export/

--- a/README.md
+++ b/README.md
@@ -408,6 +408,23 @@ Add environments to run by providing `TESTOMATIO_ENV` as comma seperated values:
 TESTOMATIO={API_KEY} TESTOMATIO_ENV="Windows, Chrome" <actual run command>
 ```
 
+### Save test results to .csv file
+Add an env to run by specifying the `TESTOMATIO_CSV_FILENAME` variable.
+
+1) using default report name:
+
+```bash
+TESTOMATIO={API_KEY} TESTOMATIO_CSV_FILENAME="report.csv" <actual run command>
+```
+
+2) using unique report name:
+
+```bash
+TESTOMATIO={API_KEY} TESTOMATIO_CSV_FILENAME="test.csv" <actual run command>
+```
+_It's create a new /export folder with csv files_
+
+
 ### Attaching Test Artifacts
 
 To save a test artifacts (screenshots and videos) of a failed test use S3 storage.

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -2,10 +2,19 @@ const chalk = require('chalk');
 
 const APP_PREFIX = chalk.gray('[TESTOMATIO]');
 
+const CSV_HEADERS = [
+  { id: 'suite_title', title: 'Suite_title' },
+  { id: 'title', title: 'Title' },
+  { id: 'status', title: 'Status' },
+  { id: 'message', title: 'Message' },
+  { id: 'stack', title: 'Stack' },
+];
+
 module.exports = Object.freeze({
   PASSED: 'passed',
   FAILED: 'failed',
   SKIPPED: 'skipped',
   FINISHED: 'finished',
   APP_PREFIX,
+  CSV_HEADERS
 });

--- a/lib/pipe/csv.js
+++ b/lib/pipe/csv.js
@@ -1,9 +1,10 @@
 const path = require("path");
 const fs = require("fs");
 const csvWriter = require('csv-writer');
+const chalk = require('chalk');
+const merge = require('lodash.merge');
 const { isSameTest, getCurrentDateTime } = require('../util');
 const { CSV_HEADERS } = require('../constants');
-const chalk = require('chalk');
 
 class CsvPipe {
 
@@ -12,12 +13,12 @@ class CsvPipe {
         this.title = params.title || process.env.TESTOMATIO_TITLE;
         this.isEnabled = true;
         this.results = [];
-        //export options
+
         this.outputDir = "export";
         this.csvFilename = process.env.TESTOMATIO_CSV_FILENAME;
         this.isCsvSave = false;
 
-        if (this.csvFilename != undefined && this.csvFilename.split(".").length > 0 ) {
+        if (this.csvFilename !== undefined && this.csvFilename.split(".").length > 0 ) {
             this.isCsvSave = true;
 
             if(this.csvFilename.split(".")[0] === "report") {
@@ -99,8 +100,7 @@ class CsvPipe {
         //Save results based on the default headers
         if(this.isCsvSave) {
             this.saveToCsv(this.results, CSV_HEADERS);
-        }
-        else console.log(chalk.yellow("You used mode without saving csv file. If you want to activate <save csv> mode -> use TESTOMATIO_CSV_FILENAME environment[EXAMPLE: TESTOMATIO_CSV_FILENAME=report.csv]!"))        
+        }       
     }
 
     toString() {

--- a/lib/pipe/csv.js
+++ b/lib/pipe/csv.js
@@ -1,0 +1,111 @@
+const path = require("path");
+const fs = require("fs");
+const csvWriter = require('csv-writer');
+const { isSameTest, getCurrentDateTime } = require('../util');
+const { CSV_HEADERS } = require('../constants');
+const chalk = require('chalk');
+
+class CsvPipe {
+
+    constructor(params, store = {}) {
+        this.store = store;
+        this.title = params.title || process.env.TESTOMATIO_TITLE;
+        this.isEnabled = true;
+        this.results = [];
+        //export options
+        this.outputDir = "export";
+        this.csvFilename = process.env.TESTOMATIO_CSV_FILENAME;
+        this.isCsvSave = false;
+
+        if (this.csvFilename != undefined && this.csvFilename.split(".").length > 0 ) {
+            this.isCsvSave = true;
+
+            if(this.csvFilename.split(".")[0] === "report") {
+                this.outputFile = path.resolve(process.cwd(), this.outputDir, "report.csv");
+            }
+            else {
+                this.outputFile = path.resolve(process.cwd(), this.outputDir, getCurrentDateTime() + "_" + this.csvFilename.split(".")[0] + ".csv");
+            }
+        }        
+    }
+
+    async createRun() {}
+
+    updateRun() {}
+
+    /**
+     * Create a folder that will contain the exported files
+     */
+    checkExportDir() {
+        if (!fs.existsSync(this.outputDir)) {
+            return fs.mkdirSync(this.outputDir);
+        }
+    }
+    /**
+     * Save data to the csv file.
+     * @param {Object} data - data that will be added to the CSV file. Example: [{suite_title: "Suite #1", test: "Test-case-1", message: "Test msg"}]
+     * @param {Object} headers - csv file headers. Example: [{ id: 'suite_title', title: 'Suite_title' }]
+     */
+    async saveToCsv(data, headers) {
+        // First, we check whether the export directory exists: if yes - OK, no - create it.
+        this.checkExportDir();
+
+        console.log(chalk.yellow(`The test results will be added to the csv. It will take some time...`));
+        //Create csv writer object
+        const writer = csvWriter.createObjectCsvWriter({
+            path: this.outputFile,
+            header: headers
+        });
+        //Save csv file based on the current data
+        try {
+            await writer.writeRecords(data);
+            console.log(chalk.green(`Recording completed! You can check the result in file = ${this.outputFile}`));
+        } catch(e) {
+            console.log('Unknown error: ', e);
+        }        
+    }
+    /**
+     * Add test data to the result array for saving. As a result of this function, we get a result object to save.
+     * @param {Object} test - object which includes each test entry.
+     */
+    addTest(test) {
+        if (!this.isEnabled) return;
+        
+        const index = this.results.findIndex(t => isSameTest(t, test)); 
+        // update if they were already added
+        if (index >= 0) {
+            this.results[index] = merge(this.results[index], test);
+            return;
+        }
+
+        const {suite_title, title, status, message, stack} = test;
+        
+        this.results.push({
+            suite_title,
+            title,
+            status,
+            message,
+            stack
+        });
+    }
+    /**
+     * Save short tests data to the csv file.
+     * @param {Object} runParams - run params.
+     */
+    async finishRun(runParams) {
+        if (!this.isEnabled) return;
+
+        if (runParams.tests) runParams.tests.forEach(t => this.addTest(t));
+        //Save results based on the default headers
+        if(this.isCsvSave) {
+            this.saveToCsv(this.results, CSV_HEADERS);
+        }
+        else console.log(chalk.yellow("You used mode without saving csv file. If you want to activate <save csv> mode -> use TESTOMATIO_CSV_FILENAME environment[EXAMPLE: TESTOMATIO_CSV_FILENAME=report.csv]!"))        
+    }
+
+    toString() {
+        return 'csv exporter';
+    }
+}
+
+module.exports = CsvPipe;

--- a/lib/pipe/index.js
+++ b/lib/pipe/index.js
@@ -5,6 +5,7 @@ const { APP_PREFIX } = require('../constants');
 const TestomatioPipe = require('./testomatio');
 const GitHubPipe = require('./github');
 const GitLabPipe = require('./gitlab');
+const CsvPipe = require('./csv');
 
 module.exports = function(params, opts) {
   const extraPipes = [];
@@ -42,6 +43,7 @@ module.exports = function(params, opts) {
     new TestomatioPipe(params, opts),
     new GitHubPipe(params, opts),
     new GitLabPipe(params, opts),
+    new CsvPipe(params, opts),
     ...extraPipes
   ];
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -146,6 +146,13 @@ const isSameTest = (test, t) => {
     && t.test_id == test.test_id
 };
 
+const getCurrentDateTime = () => {
+  const today = new Date();
+  
+  return today.getFullYear() + '_' + (today.getMonth() + 1) + '_' + today.getDate() + '_' +
+         today.getHours() + "_" + today.getMinutes() + "_" + today.getSeconds();
+}
+
 module.exports = {
   parseTest,
   parseSuite,
@@ -155,4 +162,5 @@ module.exports = {
   fetchSourceCode,
   fetchSourceCodeFromStackTrace,
   fetchFilesFromStackTrace,
+  getCurrentDateTime
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "callsite-record": "^4.1.4",
         "chalk": "^4.1.0",
         "commander": "^4.1.1",
+        "csv-writer": "^1.6.0",
         "dotenv": "^16.0.1",
         "fast-xml-parser": "^4.0.8",
         "glob": "^8.0.3",
@@ -3916,6 +3917,11 @@
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
       "dev": true
+    },
+    "node_modules/csv-writer": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/csv-writer/-/csv-writer-1.6.0.tgz",
+      "integrity": "sha512-NOx7YDFWEsM/fTRAJjRpPp8t+MKRVvniAg9wQlUKx20MFrPs73WLJhFf5iteqrxNYnsy924K3Iroh3yNHeYd2g=="
     },
     "node_modules/cucumber-expressions": {
       "version": "6.6.2",
@@ -13949,6 +13955,11 @@
           "dev": true
         }
       }
+    },
+    "csv-writer": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/csv-writer/-/csv-writer-1.6.0.tgz",
+      "integrity": "sha512-NOx7YDFWEsM/fTRAJjRpPp8t+MKRVvniAg9wQlUKx20MFrPs73WLJhFf5iteqrxNYnsy924K3Iroh3yNHeYd2g=="
     },
     "cucumber-expressions": {
       "version": "6.6.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "is-valid-path": "^0.1.1",
     "json-cycle": "^1.3.0",
     "lodash.memoize": "^4.1.2",
-    "lodash.merge": "^4.6.2"
+    "lodash.merge": "^4.6.2",
+    "csv-writer": "^1.6.0"
   },
   "files": [
     "bin",
@@ -30,6 +31,7 @@
     "testcafe"
   ],
   "scripts": {
+    "clear-exportdir": "rm -rf export/",
     "pretty": "prettier --write .",
     "lint": "eslint lib",
     "lint:fix": "eslint lib --fix",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "init": "cd ./tests/adapter/examples/cucumber && npm i",
     "test:unit": "mocha tests",
     "test:adapter": "mocha './tests/adapter/index.test.js'",
+    "test:pipes": "mocha './tests/pipes/*_test.js'",
     "test:adapter:jest:example": "jest './tests/adapter/examples/jest/index.test.js' --config='./tests/adapter/examples/jest/jest.config.js'",
     "test:adapter:mocha:example": "mocha './tests/adapter/examples/mocha/index.test.js' --config='./tests/adapter/examples/mocha/mocha.config.js'",
     "test:adapter:jasmine:example": "./tests/adapter/examples/jasmine/passReporterOpts.sh && jasmine './tests/adapter/examples/jasmine/index.test.js' --reporter=./../../../lib/adapter/jasmine.js",

--- a/tests/pipes/csv_pipe_test.js
+++ b/tests/pipes/csv_pipe_test.js
@@ -1,0 +1,77 @@
+const { expect } = require('chai');
+const fs = require('fs');
+const path = require("path");
+const CsvPipe = require('../../lib/pipe/csv');
+
+// test data
+const DATA = [
+    {
+        suite_title: 'Test suite @TEST-1',
+        title: 'Sample title',
+        status: 'pass'
+    }
+];
+const HEADERS = [
+    { id: 'suite_title', title: 'Suite_title' },
+    { id: 'title', title: 'Title' },
+    { id: 'status', title: 'Status' }
+];
+
+describe('csv pipe confirmation tests', () => {
+    let dir;
+
+    before(() => {
+        dir = path.resolve(process.cwd(), "export");
+    });
+    afterEach(() => {
+        try {
+            fs.rmdirSync(dir, { recursive: true });
+          } catch (err) {
+            console.error(`Unknown error while deleting ${dir}.`);
+          }
+    });
+    it('saveAsCsv function should save data to CSV file with default report.csv name', async () => {
+        process.env.TESTOMATIO_CSV_FILENAME = "report.csv";
+
+        const filepath = path.resolve(dir, "report.csv"); 
+
+        const csvPipe = new CsvPipe({}, {});
+
+        // call the saveToCsv function with the sample data
+        await csvPipe.saveToCsv(DATA, HEADERS);
+
+        // get list of files
+        const files = fs.readdirSync(dir);
+
+        // read the saved CSV file    
+        const savedData = fs.readFileSync(filepath, 'utf-8');
+
+        // check that file with test suffix was created
+        expect(files[0]).equal('report.csv');
+        // check that the saved data matches the input data
+        expect(savedData).equal('Suite_title,Title,Status\nTest suite @TEST-1,Sample title,pass\n');
+    });
+    it('saveAsCsv function should save data to CSV file with name based on the current date', async () => {
+        let filepath;
+
+        process.env.TESTOMATIO_CSV_FILENAME = "test.csv";
+
+        const csvPipe = new CsvPipe({}, {});
+
+        // call the saveToCsv function with the sample data
+        await csvPipe.saveToCsv(DATA, HEADERS);
+
+        // get list of files
+        const files = fs.readdirSync(dir);
+
+        filepath = path.resolve(dir, files[0]);
+
+        // read the saved CSV file    
+        const savedData = fs.readFileSync(filepath, 'utf-8');
+
+        // check that file with test suffix was created
+        expect(files[0]).to.include('_test.csv');
+        // check that the saved data matches the input data
+        expect(savedData).equal('Suite_title,Title,Status\nTest suite @TEST-1,Sample title,pass\n');
+    });
+});


### PR DESCRIPTION
I've added a new CSV pipes to save test results to a csv file.
1. Created `csv.js` file in /pipes folder
2. Added check `process.env.TESTOMATIO_CSV_FILENAME` variable: if `TESTOMATIO_CSV_FILENAME=report.csv` -> results are saved to file = report.csv, or to another file, for example `TESTOMATIO_CSV_FILENAME=test.csv` -> file name = 2023_3_14_21_18_16_test.csv (from current date)
3. Added an integration tests for `saveToCsv()` function + command to test pipes -> `npm run test:pipes`
4. "empty" message was deleted

Some results of the execution on the screens below:

- run test without csv flag => TESTOMATIO_URL=https://beta.testomat.io TESTOMATIO=<key> npx start-test-run -c 'npx mocha' --env-file .env => csv file is not saved
- run a test named report.csv by default => TESTOMATIO_URL=https://beta.testomat.io TESTOMATIO_CSV_FILENAME=report.csv TESTOMATIO=<key> npx start-test-run -c 'npx mocha' --env-file . env => export/report.csv file is saved
- TESTOMATIO_URL=https://beta.testomat.io TESTOMATIO_CSV_FILENAME=test.csv TESTOMATIO=<key> npx start-test-run -c 'npx mocha' --env-file .env => file export/2023_3_14_21_18_16_test.csv is saved

![Screenshot-not-save-1](https://user-images.githubusercontent.com/82405549/225135244-7dad8d74-6ede-4949-8848-a02b37760fd9.png)
![Screenshot-succes-save-1](https://user-images.githubusercontent.com/82405549/225135251-a619f869-8665-4f98-9f5c-235a97d70a8b.png)
