### PR TITLE
[Task-115] Remove async/await from the testomatio.addTest() function

### DIFF
--- a/lib/pipe/testomatio.js
+++ b/lib/pipe/testomatio.js
@@ -72,23 +72,22 @@ class TestomatioPipe {
     }
   }
 
-  async addTest(data) {
+  addTest(data) {
     if (!this.isEnabled) return;
     if (!this.runId) return;
     data.api_key = this.apiKey;
     data.create = this.createNewTests;
     const json = JsonCycle.stringify(data);
 
-    try {
-      return await this.axios.post(`${this.url}/api/reporter/${this.runId}/testrun`, json, {
-        maxContentLength: Infinity,
-        maxBodyLength: Infinity,
-        headers: {
-          // Overwrite Axios's automatically set Content-Type
-          'Content-Type': 'application/json',
-        },
-      });
-    } catch (err) {
+    return this.axios.post(`${this.url}/api/reporter/${this.runId}/testrun`, json, {
+      maxContentLength: Infinity,
+      maxBodyLength: Infinity,
+      headers: {
+        // Overwrite Axios's automatically set Content-Type
+        'Content-Type': 'application/json',
+      },
+    })
+    .catch((err) => {
       if (err.response) {
         if (err.response.status >= 400) {
           const responseData = err.response.data || { message: '' };
@@ -103,8 +102,7 @@ class TestomatioPipe {
       } else {
         console.log(APP_PREFIX, chalk.blue(this.title), "Report couldn't be processed", err);
       }
-    }
-
+    });
   }
 
   async finishRun(params) {


### PR DESCRIPTION
TASK-115: https://github.com/testomatio/reporter/issues/115

I have removed async/await from the addTest() function(testomatio.js file)

I have tested the following cases:

1. **Before** removing for the 150 mocha-tests. Results: Client Duration=52s / Console = 101 passing (51s),  49 failing
2. **After** removing for the 150 mocha-tests. Results: Client Duration=54s / Console = 102 passing (53s),  48 failing
3. **SETTING** various mocha opts: --timeout 5000 mode. Results: Client Duration=56s / Console = 102 passing (52s),  48 failing

![Screenshot-3](https://user-images.githubusercontent.com/82405549/228971246-21cf018e-7b3d-4538-bc30-e91786cee2c6.png)
![Screenshot-2](https://user-images.githubusercontent.com/82405549/228971250-3152ed19-925e-4a5b-8a8d-38b9522ff5bd.png)
![Screenshot-1](https://user-images.githubusercontent.com/82405549/228971253-e0cde423-a6c4-4a9d-8733-f7573518ea6d.png)

