### PR TITLE
[playwright adapter] small user log fixes: only if files exists.

### DIFF
--- a/lib/adapter/playwright.js
+++ b/lib/adapter/playwright.js
@@ -1,3 +1,4 @@
+const debug = require('debug')('@testomatio/reporter:playwright-adapter');
 const chalk = require('chalk');
 const crypto = require('crypto');
 const os = require('os');
@@ -55,8 +56,9 @@ class TestomatioReporter {
     if (!this.client) return;
 
     if (this.uploads.length && isArtifactsEnabled()) {
-      console.log(APP_PREFIX, `🎞️  Uploading ${this.uploads.length} files...`);
+      debug(APP_PREFIX, `🎬  Test data processing started.`);
 
+      let artifacts = []
       const promises = [];
 
       for (const upload of this.uploads) {
@@ -71,6 +73,9 @@ class TestomatioReporter {
           return { path: attachment.path, title, type: attachment.contentType };
         });
 
+        if (files.length > 0) {
+          artifacts.push(files);
+        }
 
         promises.push(
           this.client.addTestRun(undefined, {
@@ -79,12 +84,20 @@ class TestomatioReporter {
             suite_title,
             files,
           }),
-        );
+        );        
       }
+
+      if (artifacts.length > 0) {
+        console.log(APP_PREFIX, `🎞️  Uploading ${artifacts.length} files...`);
+      }
+
       await Promise.all(promises);
     }
 
-    await this.client.updateRunStatus(checkStatus(result.status));
+    const status = checkStatus(result.status);
+    await this.client.updateRunStatus(status);
+    
+    debug(APP_PREFIX, '🏁  Test data processing is complete!');
   }
 }
 

--- a/lib/adapter/playwright.js
+++ b/lib/adapter/playwright.js
@@ -58,7 +58,7 @@ class TestomatioReporter {
     if (this.uploads.length && isArtifactsEnabled()) {
       debug(APP_PREFIX, `🎬  Test data processing started.`);
 
-      let artifacts = []
+      const artifacts = []
       const promises = [];
 
       for (const upload of this.uploads) {


### PR DESCRIPTION
I have fixed user "file uploading" log(playwright adapter). Now the log is shown if the files exist + debug messages
file exists =>
![Screenshot-play-pr-1](https://github.com/testomatio/reporter/assets/82405549/d502dbf5-6620-43af-b4f5-048134a0d760)
no files added =>
![Screenshot-play-pr-2-no-screen](https://github.com/testomatio/reporter/assets/82405549/4a93ea31-8225-4d06-8112-cd997405030e)
files + debug =>
![Screenshot-play-pr-3-debug](https://github.com/testomatio/reporter/assets/82405549/a6659ffe-fbe5-4a63-839d-ca16a29c8295)

