### PR TITLE
[codecept adapter] fix trace uploading

### DIFF
--- a/lib/adapter/codecept.js
+++ b/lib/adapter/codecept.js
@@ -32,7 +32,7 @@ if (MAJOR_VERSION < 3) {
 
 function CodeceptReporter(config) {
   let failedTests = [];
-  let videos = [];
+  let videos = [], traces = [];
   const reportTestPromises = [];
 
   const testTimeMap = {};
@@ -54,6 +54,7 @@ function CodeceptReporter(config) {
   event.dispatcher.on(event.all.before, () => {
     recorder.add('Creating new run', () => client.createRun());
     videos = [];
+    traces = [];
   });
 
   event.dispatcher.on(event.test.before, () => {
@@ -74,22 +75,9 @@ function CodeceptReporter(config) {
     // all tests were reported and we can upload videos
     await Promise.all(reportTestPromises);
 
-    if (videos.length && upload.isArtifactsEnabled()) {
-      console.log(APP_PREFIX, `🎞️  Uploading ${videos.length} videos...`);
-
-      const promises = [];
-      for (const video of videos) {
-        const { testId, title, path, type } = video;
-        const file = { path, type, title };
-        promises.push(
-          client.addTestRun(undefined, {
-            ...stripExampleFromTitle(title),
-            test_id: testId,
-            files: [file],
-          }),
-        );
-      }
-      await Promise.all(promises);
+    if (upload.isArtifactsEnabled()) {
+      uploadAttachments(client, videos, '🎞️  Uploading', 'video');
+      uploadAttachments(client, traces, '📁 Uploading', 'trace');
     }
 
     const status = failedTests.length === 0 ? STATUS.PASSED : STATUS.FAILED;
@@ -167,9 +155,11 @@ function CodeceptReporter(config) {
     }).then(pipes => {
       testId = pipes.filter(p => p.pipe.includes('Testomatio'))[0]?.result?.data?.test_id;
 
+      debug("artifacts", artifacts);
+      
       for (const aid in artifacts) {
-        if (aid.startsWith('video')) videos.push({ testId, title, path: artifacts[aid], type: 'video/webm' }); 
-        if (aid.startsWith('trace')) files.push({ testId, title, path: artifacts[aid], type: 'application/zip' }); 
+        if (aid.startsWith('video')) videos.push({ testId, title, path: artifacts[aid], type: 'video/webm' });
+        if (aid.startsWith('trace')) traces.push({ testId, title, path: artifacts[aid], type: 'application/zip' });
       }
     });
 
@@ -241,6 +231,24 @@ function CodeceptReporter(config) {
   event.dispatcher.on(event.step.comment, step => {
     output.push(chalk.cyan.bold(step.toString()));
   });
+}
+
+async function uploadAttachments(client, attachments, messagePrefix, attachmentType) {
+  if (attachments.length > 0) {
+    console.log(APP_PREFIX, `Additional attachments: ${messagePrefix} ${attachments.length} ${attachmentType}/-s ...`);
+
+    const promises = attachments.map(async (attachment) => {
+      const { testId, title, path, type } = attachment;
+      const file = { path, type, title };
+      return client.addTestRun(undefined, {
+        ...stripExampleFromTitle(title),
+        test_id: testId,
+        files: [file],
+      });
+    });
+
+    await Promise.all(promises);
+  }
 }
 
 function parseTest(tags) {


### PR DESCRIPTION
prior to this fix, trace files were not upload.
I have added an additional processing of "trace" files similar to video uploads.
Now such artifacts as screenshots/video/trace are loaded on the client

![Screenshot-codeceptjs](https://github.com/testomatio/reporter/assets/82405549/0cfc2113-6f66-4ae0-b2d4-ca8dc570b0b0)
