### PR TITLE
[UNDEFINED PIPES] return [] instead of undefined

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -39,7 +39,7 @@ class Client {
    */
   createRun() {
     // all pipes disabled, skipping
-    if (!this.pipes.filter(p => p.isEnabled).length) return Promise.resolve();
+    if (!this.pipes?.filter(p => p.isEnabled).length) return Promise.resolve();
 
     const runParams = {
       title: this.title,
@@ -68,7 +68,7 @@ class Client {
    */
   async addTestRun(status, testData, storeArtifacts = []) {
     // all pipes disabled, skipping
-    if (!this.pipes.filter(p => p.isEnabled).length) return [];
+    if (!this.pipes?.filter(p => p.isEnabled).length) return [];
 
     if (!testData)
       testData = {
@@ -173,7 +173,7 @@ class Client {
    */
   updateRunStatus(status, isParallel = false) {
     // all pipes disabled, skipping
-    if (!this.pipes.filter(p => p.isEnabled).length) return Promise.resolve();
+    if (!this.pipes?.filter(p => p.isEnabled).length) return Promise.resolve();
 
     const runParams = { status, parallel: isParallel };
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -39,7 +39,7 @@ class Client {
    */
   createRun() {
     // all pipes disabled, skipping
-    if (!this.pipes || !this.pipes.filter(p => p.isEnabled).length) return Promise.resolve();
+    if (!this.pipes.filter(p => p.isEnabled).length) return Promise.resolve();
 
     const runParams = {
       title: this.title,
@@ -68,7 +68,7 @@ class Client {
    */
   async addTestRun(status, testData, storeArtifacts = []) {
     // all pipes disabled, skipping
-    if (!this.pipes?.filter(p => p.isEnabled).length) return;
+    if (!this.pipes.filter(p => p.isEnabled).length) return [];
 
     if (!testData)
       testData = {
@@ -173,7 +173,7 @@ class Client {
    */
   updateRunStatus(status, isParallel = false) {
     // all pipes disabled, skipping
-    if (!this.pipes?.filter(p => p.isEnabled).length) return Promise.resolve();
+    if (!this.pipes.filter(p => p.isEnabled).length) return Promise.resolve();
 
     const runParams = { status, parallel: isParallel };
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -12,7 +12,9 @@ const debug = require('debug')('@testomatio/reporter:util');
  */
 const parseTest = testTitle => {
   if (!testTitle) return null;
+  
   const captures = testTitle.match(/@T([\w\d]+)/);
+  
   if (captures) {
     return captures[1];
   }


### PR DESCRIPTION
Added a small fix = return [] instead of undefined

if I need to return `!this.pipes?.filter`, I can do that. But, in my opinion, this is unnecessary, since the `pipe` is always created.