### PR TITLE
[Cypress Adapter] Returned stacktraces & time to Testomatio (if cypress version 13+)

### DIFF
--- a/lib/adapter/cypress-plugin/index.js
+++ b/lib/adapter/cypress-plugin/index.js
@@ -26,8 +26,9 @@ const testomatioReporter = on => {
       const lastAttemptIndex = test.attempts.length - 1;
       const latestAttempt = test.attempts[lastAttemptIndex];
 
-      const time = latestAttempt.duration;
-      const error = latestAttempt.error;
+      // latestAttempt.duration && latestAttempt.error were available in adapters version up to 13 JFYI
+      const time = latestAttempt.duration || latestAttempt.wallClockDuration || test.duration;
+      let error = latestAttempt.error;
 
       let title = test.title.pop();
       const examples = title.match(/\(example (#\d+)\)/);
@@ -40,14 +41,19 @@ const testomatioReporter = on => {
       const testId = parseTest(title);
       const suiteId = parseSuite(suiteTitle);
 
-      if (error) {
+      if (!error && test.displayError) {
+        error = { message: test.displayError };
         error.inspect = function() { // eslint-disable-line func-names
-          if (this && this.codeFrame) {
-            return this.codeFrame.frame;
-          }
-          return '';
-        }
+          return this.message;
+        };
       }
+
+      const formattedError = error
+        ? {
+            message: error.message,
+            inspect: error.inspect || function() { return this.message; },
+          }
+        : '';
 
       const screenshots = Array.isArray(results.screenshots)
         ? results.screenshots
@@ -72,8 +78,16 @@ const testomatioReporter = on => {
           state = STATUS.SKIPPED;
       }
 
-      addSpecTestsPromises.push(client.addTestRun(state, {
-        title, time, example, error, files, suite_title: suiteTitle, test_id: testId, suite_id: suiteId
+      addSpecTestsPromises.push(
+        client.addTestRun(state, {
+          title, 
+          time, 
+          example, 
+          error: formattedError, 
+          files, 
+          suite_title: suiteTitle, 
+          test_id: testId, 
+          suite_id: suiteId
       }));
     }
 


### PR DESCRIPTION
[Cypress Adapter] Returned stacktraces & time to Testomatio (if cypress version 13+)

![Screenshot-cypresspstack-fix-1](https://github.com/testomatio/reporter/assets/82405549/6e86c1aa-f7ec-47e1-96b0-d76e2f8fee56)
