### PR TITLE
[RETRY TASK] Add Axios optimization: retry handling

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -3,6 +3,8 @@ const os = require('os');
 const path = require('path');
 
 const APP_PREFIX = chalk.gray('[TESTOMATIO]');
+const AXIOS_TIMEOUT = 20 * 1000; // sum = 20sec
+const AXIOS_RETRY_TIMEOUT = 5 * 1000; // sum = 5sec
 
 const TESTOMAT_TMP_STORAGE_DIR = path.join(os.tmpdir(), 'testomatio_tmp');
 
@@ -32,5 +34,7 @@ module.exports = {
   TESTOMAT_TMP_STORAGE_DIR,
   CSV_HEADERS,
   STATUS,
-  HTML_REPORT
+  HTML_REPORT,
+  AXIOS_TIMEOUT,
+  AXIOS_RETRY_TIMEOUT
 }

--- a/lib/pipe/testomatio.js
+++ b/lib/pipe/testomatio.js
@@ -46,9 +46,20 @@ class TestomatioPipe {
     // Pass the axios instance to the retry function
     axiosRetry(this.axios, {
       retries: 5, // Number of retries (Defaults to 3)
-      shouldResetTimeout: true,
-      retryCondition: () => true,
-      retryDelay: (retryCount) => retryCount * 6000,
+      shouldResetTimeout: false,
+      retryCondition: (error) => {
+        // Conditional check the error status code
+        switch (error.response.status) {
+          case 409:
+          case 429:
+          case 502:
+          case 503:
+            return true; // Retry request with response status code 409, 429, 502, 503
+          default:
+            return false; // Do not retry the others
+        }
+      },
+      retryDelay: (retryCount) => retryCount * 6000, // sum = 30sec
       onRetry: (retryCount) => {
         debug(`Retry attempt #${retryCount} failed. Retrying again...`);
       },

--- a/lib/pipe/testomatio.js
+++ b/lib/pipe/testomatio.js
@@ -6,7 +6,7 @@ const axiosRetry = require('axios-retry');
 const axios = require('axios');
 const JsonCycle = require('json-cycle');
 
-const { APP_PREFIX, STATUS } = require('../constants');
+const { APP_PREFIX, STATUS, AXIOS_TIMEOUT, AXIOS_RETRY_TIMEOUT } = require('../constants');
 const { isValidUrl, foundedTestLog } = require('../utils/utils');
 const { parseFilterParams, generateFilterRequestParams, setS3Credentials, } = require('../utils/pipe_utils');
 const { TESTOMATIO } = require('../config');
@@ -41,12 +41,12 @@ class TestomatioPipe {
     // Create a new instance of axios with a custom config
     this.axios = axios.create({
       baseURL: `${this.url.trim()}`,
-      timeout: 60000,
+      timeout: AXIOS_TIMEOUT,
     });
     // Pass the axios instance to the retry function
     axiosRetry(this.axios, {
-      retries: 5, // Number of retries (Defaults to 3)
-      shouldResetTimeout: false,
+      retries: 3, // Number of retries (Defaults to 3)
+      shouldResetTimeout: true,
       retryCondition: (error) => {
         // Conditional check the error status code
         switch (error.response.status) {
@@ -59,7 +59,7 @@ class TestomatioPipe {
             return false; // Do not retry the others
         }
       },
-      retryDelay: (retryCount) => retryCount * 6000, // sum = 30sec
+      retryDelay: (retryCount) => retryCount * AXIOS_RETRY_TIMEOUT, // sum = 15sec
       onRetry: (retryCount) => {
         debug(`Retry attempt #${retryCount} failed. Retrying again...`);
       },

--- a/lib/pipe/testomatio.js
+++ b/lib/pipe/testomatio.js
@@ -1,7 +1,11 @@
 const debug = require('debug')('@testomatio/reporter:pipe:testomatio');
 const chalk = require('chalk');
+// Retry interceptor function
+const axiosRetry = require('axios-retry');
+// Default axios instance
 const axios = require('axios');
 const JsonCycle = require('json-cycle');
+
 const { APP_PREFIX, STATUS } = require('../constants');
 const { isValidUrl, foundedTestLog } = require('../utils/utils');
 const { parseFilterParams, generateFilterRequestParams, setS3Credentials, } = require('../utils/pipe_utils');
@@ -34,10 +38,20 @@ class TestomatioPipe {
     this.groupTitle = params.groupTitle || process.env.TESTOMATIO_RUNGROUP_TITLE;
     this.env = process.env.TESTOMATIO_ENV;
     this.label = process.env.TESTOMATIO_LABEL;
-
+    // Create a new instance of axios with a custom config
     this.axios = axios.create({
       baseURL: `${this.url.trim()}`,
-      timeout: 30000
+      timeout: 60000,
+    });
+    // Pass the axios instance to the retry function
+    axiosRetry(this.axios, {
+      retries: 5, // Number of retries (Defaults to 3)
+      shouldResetTimeout: true,
+      retryCondition: () => true,
+      retryDelay: (retryCount) => retryCount * 6000,
+      onRetry: (retryCount) => {
+        debug(`Retry attempt #${retryCount} failed. Retrying again...`);
+      },
     });
 
     this.isEnabled = true;
@@ -150,10 +164,13 @@ class TestomatioPipe {
         maxContentLength: Infinity,
         maxBodyLength: Infinity,
       });
+
       this.runId = resp.data.uid;
       this.runUrl = `${this.url}/${resp.data.url.split('/').splice(3).join('/')}`;
       this.runPublicUrl = resp.data.public_url;
+
       if (resp.data.artifacts) setS3Credentials(resp.data.artifacts);
+
       this.store.runUrl = this.runUrl;
       this.store.runPublicUrl = this.runPublicUrl;
       this.store.runId = this.runId;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "@aws-sdk/lib-storage": "^3.279.0",
     "@octokit/rest": "^19.0.5",
     "aws-sdk": "^2.1072.0",
-    "axios": "^0.25.0",
+    "axios": "^1.6.2",
+    "axios-retry": "^3.9.1",
     "callsite-record": "^4.1.4",
     "chalk": "^4.1.0",
     "commander": "^4.1.1",
@@ -30,8 +31,8 @@
     "lodash.memoize": "^4.1.2",
     "lodash.merge": "^4.6.2",
     "minimatch": "^9.0.3",
-    "uuid": "^9.0.0",
-    "promise-retry": "^2.0.1"
+    "promise-retry": "^2.0.1",
+    "uuid": "^9.0.0"
   },
   "files": [
     "bin",

--- a/tests/adapter/index.test.js
+++ b/tests/adapter/index.test.js
@@ -60,7 +60,7 @@ describe('Adapters', () => {
     describe(adapterName, () => {
       describe('positive tests', () => {
         before(function (done) {
-          this.timeout(10000);
+          this.timeout(20000);
 
           registerHandlers(server, RUN_ID);
 
@@ -127,7 +127,7 @@ describe('Adapters', () => {
       describe('negative tests', () => {
         before(function (done) {
           process.env.TESTOMATIO = '';
-          this.timeout(10000);
+          this.timeout(20000);
 
           registerHandlers(server, RUN_ID);
 


### PR DESCRIPTION
Add Axios optimization: retry handling

- retries opt =5 attempts + 6s interval between retries.

Example:
(in DEBUG mode - additional message)
![Screenshot-retry-1](https://github.com/testomatio/reporter/assets/82405549/478f86b8-b4c6-4ad0-8656-2a153110ea38)
