### PR TITLE
[ISSUE-261] Don't show Artifacts error message duplicates

### DIFF
--- a/lib/adapter/codecept.js
+++ b/lib/adapter/codecept.js
@@ -130,12 +130,13 @@ function CodeceptReporter(config) {
     await Promise.all(reportTestPromises);
 
     if (upload.isArtifactsEnabled()) {
-      uploadAttachments(client, videos, '🎞️  Uploading', 'video');
-      uploadAttachments(client, traces, '📁 Uploading', 'trace');
+      await uploadAttachments(client, videos, '🎞️  Uploading', 'video');
+      await uploadAttachments(client, traces, '📁 Uploading', 'trace');
     }
 
     const status = failedTests.length === 0 ? STATUS.PASSED : STATUS.FAILED;
-    client.updateRunStatus(status);
+    
+    await client.updateRunStatus(status);
   });
 
   event.dispatcher.on(event.test.passed, test => {

--- a/lib/adapter/codecept.js
+++ b/lib/adapter/codecept.js
@@ -1,7 +1,7 @@
 const debug = require('debug')('@testomatio/reporter:adapter:codeceptjs');
 const chalk = require('chalk');
 const TestomatClient = require('../client');
-const { STATUS, APP_PREFIX, TESTOMAT_TMP_STORAGE_DIR } = require('../constants');
+const { STATUS, TESTOMAT_TMP_STORAGE_DIR } = require('../constants');
 const upload = require('../fileUploader');
 const { parseTest: getIdFromTestTitle, fileSystem } = require('../utils/utils');
 const { services } = require('../services');
@@ -311,7 +311,7 @@ function CodeceptReporter(config) {
 
 async function uploadAttachments(client, attachments, messagePrefix, attachmentType) {
   if (attachments.length > 0) {
-    console.log(APP_PREFIX, `Attachments: ${messagePrefix} ${attachments.length} ${attachmentType}/-s ...`);
+    debug(`Attachments: ${messagePrefix} ${attachments.length} ${attachmentType}/-s ...`);
 
     const promises = attachments.map(async attachment => {
       const { testId, title, path, type } = attachment;

--- a/lib/adapter/jest.js
+++ b/lib/adapter/jest.js
@@ -82,7 +82,7 @@ class JestReporter {
 
     const { numFailedTests } = results;
     const status = numFailedTests === 0 ? STATUS.PASSED : STATUS.FAILED;
-    this.client.updateRunStatus(status);
+    this.client.updateRunStatus(status); // TODO: it necessary use await?
   }
 }
 

--- a/lib/adapter/mocha.js
+++ b/lib/adapter/mocha.js
@@ -108,10 +108,10 @@ function MochaReporter(runner, opts) {
     });
   });
 
-  runner.on(EVENT_RUN_END, () => {
+  runner.on(EVENT_RUN_END, async () => {
     const status = failures === 0 ? STATUS.PASSED : STATUS.FAILED;
     console.log(chalk.bold(status), `${passes} passed, ${failures} failed, ${skipped} skipped`);
-    client.updateRunStatus(status);
+    await client.updateRunStatus(status);
   });
 }
 

--- a/lib/adapter/playwright.js
+++ b/lib/adapter/playwright.js
@@ -1,9 +1,10 @@
+const debug = require('debug')('@testomatio/reporter:adapter:playwright');
 const chalk = require('chalk');
 const crypto = require('crypto');
 const os = require('os');
 const path = require('path');
 const fs = require('fs');
-const { APP_PREFIX, STATUS: Status, TESTOMAT_TMP_STORAGE_DIR } = require('../constants');
+const { STATUS: Status, TESTOMAT_TMP_STORAGE_DIR } = require('../constants');
 const TestomatioClient = require('../client');
 const { isArtifactsEnabled } = require('../fileUploader');
 const { parseTest, fileSystem } = require('../utils/utils');
@@ -79,7 +80,7 @@ class PlaywrightReporter {
     await Promise.all(reportTestPromises);
 
     if (this.uploads.length && isArtifactsEnabled()) {
-      console.log(APP_PREFIX, `🎞️  Uploading ${this.uploads.length} files...`);
+      debug(`🎞️  Uploading ${this.uploads.length} files...`);
 
       const promises = [];
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -168,6 +168,12 @@ class Client {
 
     // global.testomatioArtifacts = [];
 
+    // additional download file processing
+    this.uploadError = 
+      artifacts.find(artifact => Object.prototype.hasOwnProperty.call(artifact, "uploadError"));
+    this.totalUploaded += 
+      artifacts.filter(artifact => !Object.prototype.hasOwnProperty.call(artifact, "uploadError") && artifact).length;
+    
     const data = {
       files,
       steps,
@@ -192,9 +198,6 @@ class Client {
       Promise.all(
         this.pipes.map(async p => {
           try {
-            this.uploadError = artifacts.find(artifact => artifact.hasOwnProperty("uploadError"));
-            this.totalUploaded = artifacts.filter(artifact => !artifact.hasOwnProperty("uploadError")).length;
-
             const result = await p.addTest(data);
 
             return { 
@@ -235,7 +238,7 @@ class Client {
 
         if(!this.totalUploaded && this.uploadError?.uploadError) {
           console.log(APP_PREFIX, 
-            `${chalk.bold('🚨 The files were not uploaded because there were problems ')} 
+            `${chalk.bold('🚨 The artifact files were not uploaded because there was problem: ')} 
               ${this.uploadError?.uploadError}`
           );
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -27,6 +27,7 @@ class Client {
     this.pipes = pipesFactory(params, store);
     this.queue = Promise.resolve();
     this.totalUploaded = 0;
+    this.uploadError = {};
     this.version = JSON.parse(fs.readFileSync(join(__dirname, '..', 'package.json')).toString()).version;
     this.executionList = Promise.resolve();
 
@@ -167,8 +168,6 @@ class Client {
 
     // global.testomatioArtifacts = [];
 
-    this.totalUploaded += uploadedFiles.filter(n => n).length;
-
     const data = {
       files,
       steps,
@@ -193,8 +192,15 @@ class Client {
       Promise.all(
         this.pipes.map(async p => {
           try {
+            this.uploadError = artifacts.find(artifact => artifact.hasOwnProperty("uploadError"));
+            this.totalUploaded = artifacts.filter(artifact => !artifact.hasOwnProperty("uploadError")).length;
+
             const result = await p.addTest(data);
-            return { pipe: p.toString(), result };
+
+            return { 
+              pipe: p.toString(),
+              result 
+            };
           } catch (err) {
             console.log(APP_PREFIX, p.toString(), err);
           }
@@ -222,15 +228,44 @@ class Client {
     this.queue = this.queue
       .then(() => Promise.all(this.pipes.map(p => p.finishRun(runParams))))
       .then(() => {
-        debug('TOTAL artifacts', this.totalUploaded);
-        if (this.totalUploaded && !upload.isArtifactsEnabled())
-          debug(`${this.totalUploaded} artifacts are not uploaded, because artifacts uploading is not enabled`);
+        const isArtifactsEnabled = upload.isArtifactsEnabled();
 
-        if (this.totalUploaded && upload.isArtifactsEnabled()) {
+        debug('TOTAL artifacts', this.totalUploaded);
+        debug('isArtifactsEnabled', isArtifactsEnabled);
+
+        if(!this.totalUploaded && this.uploadError?.uploadError) {
+          console.log(APP_PREFIX, 
+            `${chalk.bold('🚨 The files were not uploaded because there were problems ')} 
+              ${this.uploadError?.uploadError}`
+          );
+
+          return;
+        }
+
+        if (this.totalUploaded && !isArtifactsEnabled) {
+          debug(`${this.totalUploaded} artifacts are not uploaded, because artifacts uploading is not enabled`);
+          console.log(APP_PREFIX, `To ${chalk.bold('disable')} artifact uploads set: TESTOMATIO_DISABLE_ARTIFACTS=1`);
+
+          return;
+        }
+
+        if (this.totalUploaded && isArtifactsEnabled) {
+          const isBucketPrivate = !!+process.env.TESTOMATIO_PRIVATE_ARTIFACTS;
+
+          if (!isBucketPrivate) {
+            console.log(APP_PREFIX, `To enable ${chalk.bold('PRIVATE')} uploads set: TESTOMATIO_PRIVATE_ARTIFACTS=1`);
+          }
+
+          console.log(
+            APP_PREFIX,
+            `To enable ${chalk.bold('PUBLIC')} uploads remove TESTOMATIO_PRIVATE_ARTIFACTS env variable`,
+          );
+          console.log(APP_PREFIX, '---------------');
+
           console.log(
             APP_PREFIX,
             `🗄️ ${this.totalUploaded} artifacts ${
-              process.env.TESTOMATIO_PRIVATE_ARTIFACTS ? 'privately' : chalk.bold('publicly')
+              isBucketPrivate ? 'privately' : chalk.bold('publicly')
             } uploaded to S3 bucket`,
           );
         }

--- a/lib/fileUploader.js
+++ b/lib/fileUploader.js
@@ -148,21 +148,13 @@ const uploadUsingS3 = async (filePath, runId) => {
 
     return await getS3LocationLink(out);
   } 
-  catch (e) {
-    debug('S3 file uploading error: ', e);
-   
-    console.log(APP_PREFIX, `To ${chalk.bold('disable')} artifact uploads set: TESTOMATIO_DISABLE_ARTIFACTS=1`);
+  catch (err) {
+    debug('S3 file uploading error: ', err);
+    debug(APP_PREFIX, '---------------');
 
-    if (!TESTOMATIO_PRIVATE_ARTIFACTS) {
-      console.log(APP_PREFIX, `To enable ${chalk.bold('PRIVATE')} uploads set: TESTOMATIO_PRIVATE_ARTIFACTS=1`);
-    } 
-    else {
-      console.log(
-        APP_PREFIX,
-        `To enable ${chalk.bold('PUBLIC')} uploads remove TESTOMATIO_PRIVATE_ARTIFACTS env variable`,
-      );
+    return {
+      uploadError: err
     }
-    console.log(APP_PREFIX, '---------------');
   } 
 };
 
@@ -204,20 +196,13 @@ const uploadUsingS3AsBuffer = async (buffer, fileName, runId) => {
 
     return await getS3LocationLink(out);
   } 
-  catch (e) {
-    debug('S3 buffer uploading error: ', e);
+  catch (err) {
+    debug('S3 buffer uploading error: ', err);
+    debug(APP_PREFIX, '---------------');
 
-    console.log(APP_PREFIX, `To ${chalk.bold('disable')} artifact uploads set: TESTOMATIO_DISABLE_ARTIFACTS=1`);
-
-    if (!TESTOMATIO_PRIVATE_ARTIFACTS) {
-      console.log(APP_PREFIX, `To enable ${chalk.bold('PRIVATE')} uploads set: TESTOMATIO_PRIVATE_ARTIFACTS=1`);
-    } else {
-      console.log(
-        APP_PREFIX,
-        `To enable ${chalk.bold('PUBLIC')} uploads remove TESTOMATIO_PRIVATE_ARTIFACTS env variable`,
-      );
+    return {
+      uploadError: err
     }
-    console.log(APP_PREFIX, '---------------');
   }
 };
 
@@ -226,10 +211,10 @@ const uploadFileByPath = async (filePath, runId) => {
     if (isArtifactsEnabled()) {
       return uploadUsingS3(filePath, runId);
     }
-  } catch (e) {
-    debug(e);
+  } catch (err) {
+    debug(err);
 
-    console.error(chalk.red('Error occurred while uploading artifacts! '), e);
+    console.error(chalk.red('Error occurred while uploading artifacts! '));
   }
 };
 
@@ -238,10 +223,10 @@ const uploadFileAsBuffer = async (buffer, fileName, runId) => {
     if (isArtifactsEnabled()) {
       return uploadUsingS3AsBuffer(buffer, fileName, runId);
     }
-  } catch (e) {
-    debug(e);
+  } catch (err) {
+    debug(err);
 
-    console.error(chalk.red('Error occurred while uploading artifacts! '), e);
+    console.error(chalk.red('Error occurred while uploading artifacts! '));
   }
 };
 


### PR DESCRIPTION
Updates: 
- uploadUsingS3() => return {uploadError: error} and process list of available errors in client.js

![Screenshot-successe](https://github.com/testomatio/reporter/assets/82405549/98242728-5ee5-417f-a380-76bd6fe545e4)
![Screenshot-error](https://github.com/testomatio/reporter/assets/82405549/f9cf4a11-d5f0-4ab2-a87f-6fec9ddc7a79)


I added small fixes for uploadError processing, but after fix one codeceptAdapter test is **FAIL**
Need help to fix this one @DavertMik 