### PR TITLE
[TASK-241] Get test.file?.location in case if describe is not wrapped

### DIFF
--- a/lib/adapter/playwright.js
+++ b/lib/adapter/playwright.js
@@ -34,7 +34,9 @@ class PlaywrightReporter {
 
     const { error, duration } = result;
 
-    const suite_title = test.parent ? test.parent.title : null;
+    const suite_title = test.parent 
+      ? test.parent?.title 
+      : path.basename(test?.location?.file);
 
     const steps = [];
     for (const step of result.steps) {


### PR DESCRIPTION
Added quick fix to task = https://github.com/testomatio/reporter/issues/241
if no SET the describe block we should use test file name.