### PR TITLE
config usage fix: add TESTOMATIO_ENV_FILE_PATH env var

### DIFF
--- a/lib/adapter/cucumber/current.js
+++ b/lib/adapter/cucumber/current.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const { STATUS, TESTOMAT_TMP_STORAGE_DIR } = require('../../constants');
 const TestomatClient = require('../../client');
 const { parseTest, fileSystem } = require('../../utils/utils');
-const { TESTOMATIO } = require('../../config');
+const config = require('../../config');
 const { services } = require('../../services');
 
 const { GherkinDocumentParser, PickleParser } = formatterHelpers;
@@ -30,7 +30,7 @@ class CucumberReporter extends Formatter {
     this.failures = [];
     this.cases = [];
 
-    this.client = new TestomatClient({ apiKey: options.apiKey || TESTOMATIO });
+    this.client = new TestomatClient({ apiKey: options.apiKey || config.TESTOMATIO });
     this.status = STATUS.PASSED;
   }
 

--- a/lib/adapter/cucumber/legacy.js
+++ b/lib/adapter/cucumber/legacy.js
@@ -4,7 +4,7 @@ const chalk = require('chalk');
 const { parseTest, fileSystem } = require('../../utils/utils');
 const { STATUS, TESTOMAT_TMP_STORAGE_DIR } = require('../../constants');
 const TestomatClient = require('../../client');
-const { TESTOMATIO } = require('../../config');
+const config = require('../../config');
 
 const createTestomatFormatter = apiKey => {
   if (!apiKey || apiKey === '') {
@@ -152,4 +152,4 @@ const createTestomatFormatter = apiKey => {
   };
 };
 
-module.exports = createTestomatFormatter(TESTOMATIO);
+module.exports = createTestomatFormatter(config.TESTOMATIO);

--- a/lib/adapter/cypress-plugin/index.js
+++ b/lib/adapter/cypress-plugin/index.js
@@ -1,14 +1,14 @@
 const { STATUS } = require('../../constants');
 const { parseTest, parseSuite } = require('../../utils/utils');
 const TestomatClient = require('../../client');
-const { TESTOMATIO } = require('../../config');
+const config = require('../../config');
 
 const testomatioReporter = on => {
-  if (!TESTOMATIO) {
+  if (!config.TESTOMATIO) {
     console.log('TESTOMATIO key is empty, ignoring reports');
     return;
   }
-  const client = new TestomatClient({ apiKey: TESTOMATIO });
+  const client = new TestomatClient({ apiKey: config.TESTOMATIO });
 
   on('before:run', async run => {
     // TODO: looks like client.env does not exist

--- a/lib/adapter/mocha.js
+++ b/lib/adapter/mocha.js
@@ -4,7 +4,7 @@ const chalk = require('chalk');
 const TestomatClient = require('../client');
 const { STATUS, TESTOMAT_TMP_STORAGE_DIR } = require('../constants');
 const { parseTest, fileSystem } = require('../utils/utils');
-const { TESTOMATIO } = require('../config');
+const config = require('../config');
 const { services } = require('../services');
 
 const {
@@ -26,7 +26,7 @@ function MochaReporter(runner, opts) {
   let skipped = 0;
   // let artifactStore;
 
-  const apiKey = opts?.reporterOptions?.apiKey || TESTOMATIO;
+  const apiKey = opts?.reporterOptions?.apiKey || config.TESTOMATIO;
 
   const client = new TestomatClient({ apiKey });
 

--- a/lib/bin/startTest.js
+++ b/lib/bin/startTest.js
@@ -5,7 +5,7 @@ const chalk = require('chalk');
 const TestomatClient = require('../client');
 const { APP_PREFIX, STATUS } = require('../constants');
 const { version } = require('../../package.json');
-const { TESTOMATIO } = require('../config');
+const config = require('../config');
 
 console.log(chalk.cyan.bold(` 🤩 Testomat.io Reporter v${version}`));
 
@@ -21,7 +21,7 @@ program
 
     if (opts.envFile) require('dotenv').config(opts.envFile); // eslint-disable-line
 
-    const apiKey = process.env['INPUT_TESTOMATIO-KEY'] || TESTOMATIO;
+    const apiKey = process.env['INPUT_TESTOMATIO-KEY'] || config.TESTOMATIO;
     const title = process.env.TESTOMATIO_TITLE;
 
     if (launch) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -2,7 +2,7 @@
 
 if (process.env.TESTOMATIO_ENV_FILE_PATH) {
   require('dotenv').config({ path: process.env.TESTOMATIO_ENV_FILE_PATH });
-} 
+}
 
 const debug = require('debug')('@testomatio/reporter:config');
 
@@ -17,7 +17,8 @@ if (process.env.TESTOMATIO_TOKEN) {
   process.env.TESTOMATIO = process.env.TESTOMATIO_TOKEN;
 }
 
-if (process.env.TESTOMATIO === 'undefined') console.error('TESTOMATIO is "undefined". Something went wrong. Contact dev team.');
+if (process.env.TESTOMATIO === 'undefined')
+  console.error('TESTOMATIO is "undefined". Something went wrong. Contact dev team.');
 
 // select only TESTOMATIO related variables (only to print them in debug)
 const testomatioEnvVars =

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,7 +1,9 @@
-// This file is used to read environment variables from .env file and process.env
+// This file is used to read environment variables from .env file
 
-// ! uncommenting next line leads ro reading vars from .env file
-// require('dotenv').config();
+if (process.env.TESTOMATIO_ENV_FILE_PATH) {
+  require('dotenv').config({ path: process.env.TESTOMATIO_ENV_FILE_PATH });
+} 
+
 const debug = require('debug')('@testomatio/reporter:config');
 
 /* for possibility to use multiple env files (reading different paths)

--- a/lib/config.js
+++ b/lib/config.js
@@ -8,9 +8,14 @@ const debug = require('debug')('@testomatio/reporter:config');
 const dotenv = require('dotenv');
 const envFileVars = dotenv.config({ path: '.env' }).parsed; */
 
-const TESTOMATIO = process.env.TESTOMATIO || process.env.TESTOMATIO_API_KEY || process.env.TESTOMATIO_TOKEN || '';
-if (TESTOMATIO === 'undefined') console.error('TESTOMATIO is "undefined". Something went wrong. Contact dev team.');
-process.env.TESTOMATIO = TESTOMATIO;
+if (process.env.TESTOMATIO_API_KEY) {
+  process.env.TESTOMATIO = process.env.TESTOMATIO_API_KEY;
+}
+if (process.env.TESTOMATIO_TOKEN) {
+  process.env.TESTOMATIO = process.env.TESTOMATIO_TOKEN;
+}
+
+if (process.env.TESTOMATIO === 'undefined') console.error('TESTOMATIO is "undefined". Something went wrong. Contact dev team.');
 
 // select only TESTOMATIO related variables (only to print them in debug)
 const testomatioEnvVars =
@@ -26,4 +31,3 @@ debug('TESTOMATIO variables:', testomatioEnvVars);
 const config = process.env;
 
 module.exports = config;
-module.exports.TESTOMATIO = TESTOMATIO;

--- a/lib/pipe/testomatio.js
+++ b/lib/pipe/testomatio.js
@@ -9,7 +9,7 @@ const JsonCycle = require('json-cycle');
 const { APP_PREFIX, STATUS, AXIOS_TIMEOUT, AXIOS_RETRY_TIMEOUT } = require('../constants');
 const { isValidUrl, foundedTestLog } = require('../utils/utils');
 const { parseFilterParams, generateFilterRequestParams, setS3Credentials, } = require('../utils/pipe_utils');
-const { TESTOMATIO } = require('../config');
+const config = require('../config');
 
 if (process.env.TESTOMATIO_RUN) {
   process.env.runId = process.env.TESTOMATIO_RUN;
@@ -25,7 +25,7 @@ class TestomatioPipe {
   constructor(params, store) {
     this.isEnabled = false;
     this.url = params.testomatioUrl || process.env.TESTOMATIO_URL || 'https://app.testomat.io';
-    this.apiKey = params.apiKey || TESTOMATIO;
+    this.apiKey = params.apiKey || config.TESTOMATIO;
     debug('Testomatio Pipe: ', this.apiKey ? 'API KEY' : '*no api key*');
     if (!this.apiKey) {
       return;

--- a/lib/pipe/testomatio.js
+++ b/lib/pipe/testomatio.js
@@ -8,7 +8,7 @@ const JsonCycle = require('json-cycle');
 
 const { APP_PREFIX, STATUS, AXIOS_TIMEOUT, AXIOS_RETRY_TIMEOUT } = require('../constants');
 const { isValidUrl, foundedTestLog } = require('../utils/utils');
-const { parseFilterParams, generateFilterRequestParams, setS3Credentials, } = require('../utils/pipe_utils');
+const { parseFilterParams, generateFilterRequestParams, setS3Credentials } = require('../utils/pipe_utils');
 const config = require('../config');
 
 if (process.env.TESTOMATIO_RUN) {
@@ -47,7 +47,7 @@ class TestomatioPipe {
     axiosRetry(this.axios, {
       retries: 3, // Number of retries (Defaults to 3)
       shouldResetTimeout: true,
-      retryCondition: (error) => {
+      retryCondition: error => {
         // Conditional check the error status code
         switch (error.response.status) {
           case 409:
@@ -59,8 +59,8 @@ class TestomatioPipe {
             return false; // Do not retry the others
         }
       },
-      retryDelay: (retryCount) => retryCount * AXIOS_RETRY_TIMEOUT, // sum = 15sec
-      onRetry: (retryCount) => {
+      retryDelay: retryCount => retryCount * AXIOS_RETRY_TIMEOUT, // sum = 15sec
+      onRetry: retryCount => {
         debug(`Retry attempt #${retryCount} failed. Retrying again...`);
       },
     });
@@ -82,7 +82,7 @@ class TestomatioPipe {
   /**
    * Asynchronously prepares and retrieves the Testomat.io test grepList based on the provided options.
    * @param {Object} opts - The options for preparing the test grepList.
-   * @returns {Promise<string[]>} - An array containing the retrieved 
+   * @returns {Promise<string[]>} - An array containing the retrieved
    * test grepList, or an empty array if no tests are found or the request is disabled.
    * @throws {Error} - Throws an error if there was a problem while making the request.
    */
@@ -95,7 +95,7 @@ class TestomatioPipe {
       const q = generateFilterRequestParams({
         type,
         id,
-        apiKey: this.apiKey.trim()
+        apiKey: this.apiKey.trim(),
       });
 
       if (!q) {
@@ -109,14 +109,10 @@ class TestomatioPipe {
         foundedTestLog(APP_PREFIX, data.tests);
         return data.tests;
       }
-      
+
       console.log(APP_PREFIX, `⛔  No tests found for your --filter --> ${type}=${id}`);
-    }
-    catch (err) {
-      console.error(
-        APP_PREFIX,
-        `🚩 Error getting Testomat.io test grepList: ${err}`,
-      );
+    } catch (err) {
+      console.error(APP_PREFIX, `🚩 Error getting Testomat.io test grepList: ${err}`);
     }
   }
 
@@ -212,37 +208,38 @@ class TestomatioPipe {
 
     debug('Adding test', json);
 
-    return this.axios.post(`/api/reporter/${this.runId}/testrun`, json, {
-      maxContentLength: Infinity,
-      maxBodyLength: Infinity,
-      headers: {
-        // Overwrite Axios's automatically set Content-Type
-        'Content-Type': 'application/json',
-      },
-    })
-    .catch(err => {
-      if (err.response) {
-        if (err.response.status >= 400) {
-          const responseData = err.response.data || { message: '' };
+    return this.axios
+      .post(`/api/reporter/${this.runId}/testrun`, json, {
+        maxContentLength: Infinity,
+        maxBodyLength: Infinity,
+        headers: {
+          // Overwrite Axios's automatically set Content-Type
+          'Content-Type': 'application/json',
+        },
+      })
+      .catch(err => {
+        if (err.response) {
+          if (err.response.status >= 400) {
+            const responseData = err.response.data || { message: '' };
+            console.log(
+              APP_PREFIX,
+              chalk.yellow(`Warning: ${responseData.message} (${err.response.status})`),
+              chalk.grey(data?.title || ''),
+            );
+            if (err.response.data.message.includes('could not be matched')) {
+              this.hasUnmatchedTests = true;
+            }
+            return;
+          }
           console.log(
             APP_PREFIX,
-            chalk.yellow(`Warning: ${responseData.message} (${err.response.status})`),
-            chalk.grey(data?.title || ''),
+            chalk.yellow(`Warning: ${data?.title || ''} (${err.response?.status})`),
+            `Report couldn't be processed: ${err?.response?.data?.message}`,
           );
-          if (err.response.data.message.includes('could not be matched')) {
-            this.hasUnmatchedTests = true;
-          }
-          return;
+        } else {
+          console.log(APP_PREFIX, chalk.blue(data?.title || ''), "Report couldn't be processed", err);
         }
-        console.log(
-          APP_PREFIX,
-          chalk.yellow(`Warning: ${data?.title || ''} (${err.response?.status})`),
-          `Report couldn't be processed: ${err?.response?.data?.message}`,
-        );
-      } else {
-        console.log(APP_PREFIX, chalk.blue(data?.title || ''), "Report couldn't be processed", err);
-      }
-    });
+      });
   }
 
   /**

--- a/lib/xmlReader.js
+++ b/lib/xmlReader.js
@@ -15,7 +15,7 @@ const {
 const upload = require('./fileUploader');
 const pipesFactory = require('./pipe');
 const adapterFactory = require('./junit-adapter');
-const { TESTOMATIO } = require('./config');
+const config = require('./config');
 
 const TESTOMATIO_URL = process.env.TESTOMATIO_URL || 'https://app.testomat.io';
 const { TESTOMATIO_RUNGROUP_TITLE, TESTOMATIO_TITLE, TESTOMATIO_ENV, TESTOMATIO_RUN } = process.env;
@@ -33,7 +33,7 @@ const reduceOptions = {};
 class XmlReader {
   constructor(opts = {}) {
     this.requestParams = {
-      apiKey: opts.apiKey || TESTOMATIO,
+      apiKey: opts.apiKey || config.TESTOMATIO,
       url: opts.url || TESTOMATIO_URL,
       title: TESTOMATIO_TITLE,
       env: TESTOMATIO_ENV,


### PR DESCRIPTION
this is required when we use `npx start-test-run -c`, because need to get env vars (e.g. `TESTOMATIO`) before user test run script (where he can read `.env` on his own)