### PR TITLE
added TESTOMATIO_STACK_PASSED variable

### DIFF
--- a/lib/pipe/testomatio.js
+++ b/lib/pipe/testomatio.js
@@ -199,9 +199,15 @@ class TestomatioPipe {
     if (!this.runId) return;
     data.api_key = this.apiKey;
     data.create = this.createNewTests;
+
+    if (!process.env.TESTOMATIO_STACK_PASSED && data.status === STATUS.PASSED) {
+      data.stack = null;
+    }
+
     const json = JsonCycle.stringify(data);
 
     debug('Adding test', json);
+
 
     return this.axios
       .post(`/api/reporter/${this.runId}/testrun`, json, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@testomatio/reporter",
-  "version": "1.3.0-ignore-stack-for-passed.1",
+  "version": "1.2.0",
   "description": "Testomatio Reporter Client",
   "main": "./lib/reporter.js",
   "typings": "typings/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@testomatio/reporter",
-  "version": "1.2.0",
+  "version": "1.3.0-ignore-stack-for-passed.1",
   "description": "Testomatio Reporter Client",
   "main": "./lib/reporter.js",
   "typings": "typings/index.d.ts",


### PR DESCRIPTION
Ignore stack traces for passed tests unless `TESTOMATIO_STACK_PASSED` variable set

This should improve performance of reporting