### PR TITLE
docs: add required permissions on github actions to post a comment with the report on pull requests

### DIFF
--- a/docs/pipes/github.md
+++ b/docs/pipes/github.md
@@ -27,6 +27,10 @@ on:
 
 jobs:
   test:
+    permissions:
+      # These permissions are required for testomat to create comments on pull requests
+      issues: write
+      pull-requests: write
     # pre-execution steps
     - name: Run Tests
       run: <actual test command with @testomatio/reporter enabled>


### PR DESCRIPTION
These permissions are required for the github action to work properly, otherwise we get the following error:
```
[TESTOMATIO] GitHub Couldn't create GitHub report HttpError: Resource not accessible by integration
```