### PR TITLE
chore: update github-actions dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/linter-and-tests.yml
+++ b/.github/workflows/linter-and-tests.yml
@@ -22,9 +22,9 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm i

--- a/.github/workflows/publish-docs-api.yml
+++ b/.github/workflows/publish-docs-api.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       # first checkout your code
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # then use redoc-cli-github-action to generate your HTML bundle
       - name: Generate and rename Redoc documentation
@@ -19,7 +19,7 @@ jobs:
           npx redoc-cli bundle testomat-api-definition.yml
           mv redoc-static.html index.html
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3 # https://github.com/peaceiris/actions-gh-pages
+        uses: peaceiris/actions-gh-pages@v4 # https://github.com/peaceiris/actions-gh-pages
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: .

--- a/.github/workflows/publish-newman-reporter-to-npm.yml
+++ b/.github/workflows/publish-newman-reporter-to-npm.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/publish-reporter-to-npm.yml
+++ b/.github/workflows/publish-reporter-to-npm.yml
@@ -7,17 +7,17 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.release.target_commitish }}
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
       - run: npm i
       - run: git config --global user.name "GitHub CD bot"
       - run: git config --global user.email "github-cd-bot@example.com"
       - run: npm version ${{ github.event.release.tag_name }}
-      - uses: JS-DevTools/npm-publish@v1
+      - uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPM_TOKEN }}
           # use "beta" tag if relevant, otherwise use "latest"

--- a/.github/workflows/publish-testcafe-reporter-to-npm.yml
+++ b/.github/workflows/publish-testcafe-reporter-to-npm.yml
@@ -6,9 +6,9 @@ jobs:
     continue-on-error: true
     if: github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
This PR includes the update of the used github-actions and configures dependabot to receive PR monthly if there is a dependency update. The frequency can be modified to weekly or daily if you prefer.

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>

