### PR TITLE
changed TESTOMATIO_MAX_REQUEST_FAILURES

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -74,14 +74,14 @@ Example:
 TESTOMATIO_INTERCEPT_CONSOLE_LOGS=true <actual run command>
 ```
 
-#### `TESTOMATIO_MAX_REQUEST_FAILURES_COUNT`
+#### `TESTOMATIO_MAX_REQUEST_FAILURES`
 
-Maximum number of failed requests within 60 seconds. Default is 10.
+Maximum number of failed requests. If more requests fail, reporting will stop.
 
 Example:
 
 ```
-TESTOMATIO_MAX_REQUEST_FAILURES_COUNT=5 <actual run command>
+TESTOMATIO_MAX_REQUEST_FAILURES=5 <actual run command>
 ```
 
 #### `TESTOMATIO_PROCEED`

--- a/lib/pipe/testomatio.js
+++ b/lib/pipe/testomatio.js
@@ -235,7 +235,14 @@ class TestomatioPipe {
   #cancelTestReportingInCaseOfTooManyReqFailures() {
     if (!process.env.TESTOMATIO_MAX_REQUEST_FAILURES) return;
 
-    return this.requestFailures >= parseInt(process.env.TESTOMATIO_MAX_REQUEST_FAILURES, 10);
+    const cancelReporting = this.requestFailures >= parseInt(process.env.TESTOMATIO_MAX_REQUEST_FAILURES, 10);
+    if (cancelReporting) {
+      this.reportingCanceledDueToReqFailures = true;
+      const errorMessage = 
+        `⚠️ ${process.env.TESTOMATIO_MAX_REQUEST_FAILURES} requests were failed, reporting to Testomat aborted.`;
+      console.warn(`${APP_PREFIX} ${chalk.yellow(errorMessage)}`);
+    }
+    return cancelReporting;
   }
 
   #uploadSingleTest = async data => {
@@ -258,6 +265,7 @@ class TestomatioPipe {
       .post(`/api/reporter/${this.runId}/testrun`, json, axiosAddTestrunRequestConfig)
       .catch(err => {
         this.requestFailures++;
+        this.notReportedTestsCount++;
         if (err.response) {
           if (err.response.status >= 400) {
             const responseData = err.response.data || { message: '' };
@@ -307,6 +315,7 @@ class TestomatioPipe {
       )
       .catch(err => {
         this.requestFailures++;
+        this.notReportedTestsCount += testsToSend.length;
         if (err.response) {
           if (err.response.status >= 400) {
             const responseData = err.response.data || { message: '' };

--- a/lib/pipe/testomatio.js
+++ b/lib/pipe/testomatio.js
@@ -98,6 +98,7 @@ class TestomatioPipe {
     this.runId = params.runId || process.env.runId;
     this.createNewTests = params.createNewTests ?? !!process.env.TESTOMATIO_CREATE;
     this.hasUnmatchedTests = false;
+    this.requestFailures = 0;
 
     if (!isValidUrl(this.url.trim())) {
       this.isEnabled = false;
@@ -229,37 +230,18 @@ class TestomatioPipe {
 
   /**
    * Decides whether to skip test reporting in case of too many request failures
-   * @param {TestData} testData
    * @returns {boolean}
    */
-  #cancelTestReportingInCaseOfTooManyReqFailures(testData) {
-    if (this.reportingCanceledDueToReqFailures) return true;
+  #cancelTestReportingInCaseOfTooManyReqFailures() {
+    if (!process.env.TESTOMATIO_MAX_REQUEST_FAILURES) return;
 
-    const retriesCountWithinTime = this.retriesTimestamps.filter(
-      timestamp => Date.now() - timestamp < REPORTER_REQUEST_RETRIES.withinTimeSeconds * 1000,
-    ).length;
-    debug(`${retriesCountWithinTime} failed requests within ${REPORTER_REQUEST_RETRIES.withinTimeSeconds}s`);
-
-    if (retriesCountWithinTime > REPORTER_REQUEST_RETRIES.maxTotalRetries) {
-      const errorMessage = chalk.yellow(
-        `${retriesCountWithinTime} requests were failed within ${REPORTER_REQUEST_RETRIES.withinTimeSeconds}s,\
- reporting for test "${testData.title}" to Testomat is skipped`,
-      );
-      console.warn(`${APP_PREFIX} ${errorMessage}`);
-
-      this.reportingCanceledDueToReqFailures = true;
-      this.notReportedTestsCount++;
-
-      return true;
-    }
-
-    return false;
+    return this.requestFailures >= parseInt(process.env.TESTOMATIO_MAX_REQUEST_FAILURES, 10);
   }
 
   #uploadSingleTest = async data => {
     if (!this.isEnabled) return;
     if (!this.runId) return;
-    if (this.#cancelTestReportingInCaseOfTooManyReqFailures(data)) return;
+    if (this.#cancelTestReportingInCaseOfTooManyReqFailures()) return;
 
     data.api_key = this.apiKey;
     data.create = this.createNewTests;
@@ -275,6 +257,7 @@ class TestomatioPipe {
     return this.axios
       .post(`/api/reporter/${this.runId}/testrun`, json, axiosAddTestrunRequestConfig)
       .catch(err => {
+        this.requestFailures++;
         if (err.response) {
           if (err.response.status >= 400) {
             const responseData = err.response.data || { message: '' };
@@ -308,6 +291,7 @@ class TestomatioPipe {
     this.batch.batchIndex++;
     if (!this.batch.isEnabled) return;
     if (!this.batch.tests.length) return;
+    if (this.#cancelTestReportingInCaseOfTooManyReqFailures()) return;
 
     // get tests from batch and clear batch
     const testsToSend = this.batch.tests.splice(0);
@@ -322,6 +306,7 @@ class TestomatioPipe {
         axiosAddTestrunRequestConfig,
       )
       .catch(err => {
+        this.requestFailures++;
         if (err.response) {
           if (err.response.status >= 400) {
             const responseData = err.response.data || { message: '' };


### PR DESCRIPTION
Simplified `TESTOMATIO_MAX_REQUEST_FAILURES` . Previous implementation was to complex for clients

As of https://github.com/testomatio/auth0-issues/issues/123