### PR TITLE
CI: run linter and prettier only once

### DIFF
--- a/.github/workflows/linter-and-tests.yml
+++ b/.github/workflows/linter-and-tests.yml
@@ -13,14 +13,21 @@ on:
     branches: [master]
 
 jobs:
-  build:
+  linter:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+      - run: npm i
+      - run: npm run lint
+      - run: npm run pretty:fix
 
+  tests:
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.4]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
+        node-version: [18.x, 20.x, 22.x]
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
@@ -28,7 +35,5 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm i
-      - run: npm run lint
-      - run: npm run pretty:fix
       - run: npm run test
       - run: npm run test:storage

--- a/.github/workflows/linter-and-tests.yml
+++ b/.github/workflows/linter-and-tests.yml
@@ -13,17 +13,22 @@ on:
     branches: [master]
 
 jobs:
-  linter:
+  linter-and-tests-on-latest-node:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: latest
+      - run: node -v
       - run: npm i
       - run: npm run lint
       - run: npm run pretty:fix
+      - run: npm run test
+      - run: npm run test:storage
+    
 
-  tests:
+  tests-on-previous-node-versions:
     runs-on: ubuntu-latest
     needs: linter
     strategy:

--- a/.github/workflows/linter-and-tests.yml
+++ b/.github/workflows/linter-and-tests.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   linter-and-tests-on-latest-node:
     runs-on: ubuntu-latest
-    name: Linter&Tests (latest node)
+    name: Linter&tests (latest node)
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -30,14 +30,13 @@ jobs:
 
   tests-on-previous-node-versions:
     runs-on: ubuntu-latest
-    name: Tests on previous node versions
     needs: linter-and-tests-on-latest-node
     strategy:
       matrix:
         node-version: [18.x, 20.x, 22.x]
     steps:
       - uses: actions/checkout@v4
-      - name: Tests on node ${{ matrix.node-version }}
+      - name: Tests (node ${{ matrix.node-version }})
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/linter-and-tests.yml
+++ b/.github/workflows/linter-and-tests.yml
@@ -25,6 +25,7 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
+    needs: linter
     strategy:
       matrix:
         node-version: [18.x, 20.x, 22.x]

--- a/.github/workflows/linter-and-tests.yml
+++ b/.github/workflows/linter-and-tests.yml
@@ -33,7 +33,7 @@ jobs:
     needs: linter-and-tests-on-latest-node
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x]
     steps:
       - uses: actions/checkout@v4
       - name: Tests (node ${{ matrix.node-version }})

--- a/.github/workflows/linter-and-tests.yml
+++ b/.github/workflows/linter-and-tests.yml
@@ -30,7 +30,7 @@ jobs:
 
   tests-on-previous-node-versions:
     runs-on: ubuntu-latest
-    needs: linter
+    needs: linter-and-tests-on-latest-node
     strategy:
       matrix:
         node-version: [18.x, 20.x, 22.x]

--- a/.github/workflows/linter-and-tests.yml
+++ b/.github/workflows/linter-and-tests.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   linter-and-tests-on-latest-node:
     runs-on: ubuntu-latest
+    name: Linter&Tests (latest node)
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -26,17 +27,17 @@ jobs:
       - run: npm run pretty:fix
       - run: npm run test
       - run: npm run test:storage
-    
 
   tests-on-previous-node-versions:
     runs-on: ubuntu-latest
+    name: Tests on previous node versions
     needs: linter-and-tests-on-latest-node
     strategy:
       matrix:
         node-version: [18.x, 20.x, 22.x]
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Tests on node ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/linter-and-tests.yml
+++ b/.github/workflows/linter-and-tests.yml
@@ -28,7 +28,7 @@ jobs:
       - run: npm run test
       - run: npm run test:storage
 
-  tests-on-previous-node-versions:
+  tests:
     runs-on: ubuntu-latest
     needs: linter-and-tests-on-latest-node
     strategy:


### PR DESCRIPTION
- run run linter and prettier only once
- after linter run tests (do not run tests on multiple versions if linter or tests on latest version failed)
- use latest node by default

![image](https://github.com/user-attachments/assets/e1c93d01-9ac9-4071-a050-4a9db90b2cc8)
