### PR TITLE
update open api

### DIFF
--- a/testomat-api-definition.yml
+++ b/testomat-api-definition.yml
@@ -249,9 +249,3 @@ components:
         box:
           type: boolean
           description: Indicates if the step should be boxed
-
-    Steps:
-      type: array
-      items:
-        $ref: '#/components/schemas/Step'
-      description: An array of steps

--- a/testomat-api-definition.yml
+++ b/testomat-api-definition.yml
@@ -36,7 +36,12 @@ paths:
                     description: Run ID used to send data to in following requests
                   url:
                     type: string
+        400:
+          description: Bad request - check the request body and/or parameters
+        401:
+          description: Unauthorized - check your API key
 
+  /api/reporter/{runId}:
     put:
       summary: Update or finish existing run
       description: |
@@ -61,8 +66,12 @@ paths:
             schema:
               $ref: '#/components/schemas/UpdateRunData'
       responses:
-        '200':
+        200:
           description: OK
+        400:
+          description: Bad request - check the request body and/or parameters
+        401:
+          description: Unauthorized - check your API key
 
   /api/reporter/{runId}/testrun:
     post:
@@ -75,7 +84,7 @@ paths:
           schema:
             type: string
         - in: query
-          name: apiKey
+          name: api_key
           required: true
           description: Your Testomat.io API key
           schema:
@@ -88,13 +97,13 @@ paths:
             schema:
               $ref: '#/components/schemas/TestData'
       responses:
-        '200':
+        200:
           description: OK
-        '400':
+        400:
           description: Bad request - check the request body and/or parameters
-        '401':
+        401:
           description: Unauthorized - check your API key
-        '404':
+        404:
           description: Not found - check the runId parameter
 
 components:
@@ -106,7 +115,7 @@ components:
         - failed
         - skipped
     RunStatusEvent:
-      description:
+      description: |
         The final status of the run. Suffix _parallel and marks that only one part of this run has finished. To finish parallel run, send additional request with status=finish.
         Set status explicitly with `pass` or `fail` statuses or use `finish` status to calculate final status from test run results.
       type: string
@@ -136,7 +145,7 @@ components:
           description: Add a run to rungroup matching this group by its title. If rungroup does not exist, it will be created.
         parallel:
           type: boolean
-          description: Whether to create a prallell run
+          description: Whether to create a parallel run
 
     UpdateRunData:
       type: object
@@ -164,6 +173,7 @@ components:
           items:
             $ref: '#/components/schemas/TestData'
           description: The details of each test
+
     TestData:
       type: object
       properties:
@@ -200,8 +210,48 @@ components:
             type: string
           description: An array of URLs for uploaded artifacts associated with the test
         steps:
-          type: string
+          type: array
+          items:
+            $ref: '#/components/schemas/Step'
           description: The steps taken during the test
         code:
           type: string
           description: The code executed during the test
+
+    Step:
+      type: object
+      properties:
+        category:
+          type: string
+          description: The category of the step
+        title:
+          type: string
+          description: The title of the step
+        duration:
+          type: number
+          description: The duration of the step in seconds
+        steps:
+          type: array
+          items:
+            $ref: '#/components/schemas/Step'
+          description: An array of nested steps
+        error:
+          type: object
+          description: An error object associated with the step
+        options:
+          type: object
+          $ref: '#/components/schemas/StepOptions'
+          description: Options for the step, such as whether it should be boxed
+
+    StepOptions:
+      type: object
+      properties:
+        box:
+          type: boolean
+          description: Indicates if the step should be boxed
+
+    Steps:
+      type: array
+      items:
+        $ref: '#/components/schemas/Step'
+      description: An array of steps


### PR DESCRIPTION
This pull request includes several updates to the `testomat-api-definition.yml` file, focusing on enhancing API responses, correcting parameter names, and expanding schema definitions. The most important changes include adding new response codes, correcting parameter names, and extending the `TestData` schema with new properties.

Enhancements to API responses:

* Added `400` and `401` response codes to multiple endpoints to handle bad requests and unauthorized access. (`testomat-api-definition.yml`) [[1]](diffhunk://#diff-3d61b129b1847ed23ecacc6e3c3ef29442292f6e7517f8ce70be39fbb9f45124R39-R44) [[2]](diffhunk://#diff-3d61b129b1847ed23ecacc6e3c3ef29442292f6e7517f8ce70be39fbb9f45124L64-R74) [[3]](diffhunk://#diff-3d61b129b1847ed23ecacc6e3c3ef29442292f6e7517f8ce70be39fbb9f45124L91-R106)

Parameter name corrections:

* Changed the `apiKey` parameter to `api_key` to standardize naming conventions. (`testomat-api-definition.yml`)

Schema expansions:

* Updated the `TestData` schema to include an array of `Step` objects, detailing the steps taken during a test. (`testomat-api-definition.yml`)
* Added a new `Step` object schema with properties such as `category`, `title`, `duration`, and nested steps. (`testomat-api-definition.yml`)
* Introduced `StepOptions` and `Steps` schemas to provide additional details and options for test steps. (`testomat-api-definition.yml`)

Minor corrections:

* Fixed a typo in the description of the `parallel` property. (`testomat-api-definition.yml`)
* Added missing description for `RunStatusEvent`. (`testomat-api-definition.yml`)

https://github.com/testomatio/reporter/issues/428