### PR TITLE
Refactor artifact path handling in PlaywrightReporter

### DIFF
--- a/src/adapter/playwright.js
+++ b/src/adapter/playwright.js
@@ -9,6 +9,7 @@ import TestomatioClient from '../client.js';
 import { getTestomatIdFromTestTitle, fileSystem } from '../utils/utils.js';
 import { services } from '../services/index.js';
 import { dataStorage } from '../data-storage.js';
+import { extensionMap } from '../utils/constants.js';
 
 const reportTestPromises = [];
 
@@ -129,15 +130,9 @@ class PlaywrightReporter {
     }
     if (artifact.body) {
       let filePath = generateTmpFilepath(artifact.name);
-      // Check if file already has an extension
       const hasExtension = artifact.name && path.extname(artifact.name);
       if (!hasExtension && artifact.contentType) {
-        const mimeType = artifact.contentType.split('/')[1];
-        const extensionMap = {
-          jpeg: 'jpg',
-          plain: 'txt',
-        };
-        const extension = extensionMap[mimeType] || mimeType;
+        const extension = extensionMap[artifact.contentType] || artifact.contentType.split('/')[1];
         if (extension) filePath += `.${extension}`;
       }
       fs.writeFileSync(filePath, artifact.body);

--- a/src/adapter/playwright.js
+++ b/src/adapter/playwright.js
@@ -125,20 +125,24 @@ class PlaywrightReporter {
   #getArtifactPath(artifact) {
     if (artifact.path) {
       if (path.isAbsolute(artifact.path)) return artifact.path;
-
       return path.join(this.config.outputDir || this.config.projects[0].outputDir, artifact.path);
     }
-
     if (artifact.body) {
       let filePath = generateTmpFilepath(artifact.name);
-
-      const extension = artifact.contentType?.split('/')[1]?.replace('jpeg', 'jpg');
-      if (extension) filePath += `.${extension}`;
-
+      // Check if file already has an extension
+      const hasExtension = artifact.name && path.extname(artifact.name);
+      if (!hasExtension && artifact.contentType) {
+        const mimeType = artifact.contentType.split('/')[1];
+        const extensionMap = {
+          jpeg: 'jpg',
+          plain: 'txt',
+        };
+        const extension = extensionMap[mimeType] || mimeType;
+        if (extension) filePath += `.${extension}`;
+      }
       fs.writeFileSync(filePath, artifact.body);
       return filePath;
     }
-
     return null;
   }
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,18 +1,12 @@
-"use strict";
-
-const extensionMap = {
-    'application/json': 'json',
-    'text/plain': 'txt',
-    'image/jpeg': 'jpg',
-    'image/png': 'png',
-    'text/html': 'html',
-    'text/css': 'css',
-    'text/javascript': 'js',
-    'application/pdf': 'pdf',
-    'application/xml': 'xml',
-    'text/xml': 'xml'
+export const extensionMap = {
+  'application/json': 'json',
+  'text/plain': 'txt',
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'text/html': 'html',
+  'text/css': 'css',
+  'text/javascript': 'js',
+  'application/pdf': 'pdf',
+  'application/xml': 'xml',
+  'text/xml': 'xml',
 };
-
-module.exports = {
-    extensionMap
-}; 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const extensionMap = {
+    'application/json': 'json',
+    'text/plain': 'txt',
+    'image/jpeg': 'jpg',
+    'image/png': 'png',
+    'text/html': 'html',
+    'text/css': 'css',
+    'text/javascript': 'js',
+    'application/pdf': 'pdf',
+    'application/xml': 'xml',
+    'text/xml': 'xml'
+};
+
+module.exports = {
+    extensionMap
+}; 

--- a/tests/adapter/codecept.test.js
+++ b/tests/adapter/codecept.test.js
@@ -7,7 +7,7 @@ import { promisify } from 'util';
 
 const execAsync = promisify(exec);
 
-describe('CodeceptJS Adapter Tests', function() {
+describe('CodeceptJS Adapter Tests', function () {
   this.timeout(60000); // Longer timeout for test execution
 
   let debugFilePath;
@@ -29,7 +29,7 @@ describe('CodeceptJS Adapter Tests', function() {
   // Helper function to run CodeceptJS tests with debug enabled
   async function runCodeceptTest(testFile = 'simple_test.js', extraEnv = {}) {
     const cmd = `npx codeceptjs run ${testFile}`;
-    
+
     let stdout, stderr;
     try {
       const result = await execAsync(cmd, {
@@ -40,8 +40,8 @@ describe('CodeceptJS Adapter Tests', function() {
           DEBUG: '1',
           TESTOMATIO_DEBUG: '1',
           TESTOMATIO_DISABLE_BATCH_UPLOAD: '1',
-          ...extraEnv
-        }
+          ...extraEnv,
+        },
       });
       stdout = result.stdout;
       stderr = result.stderr;
@@ -51,36 +51,39 @@ describe('CodeceptJS Adapter Tests', function() {
       stderr = error.stderr || '';
       console.log('Test execution completed with some failures (expected)');
     }
-    
+
     console.log('Test execution output:', stdout);
     if (stderr) console.log('Test execution stderr:', stderr);
 
     // Verify debug file was created and return parsed data
     expect(fs.existsSync(debugFilePath)).to.be.true;
-    
+
     const debugContent = fs.readFileSync(debugFilePath, 'utf-8');
-    const debugLines = debugContent.trim().split('\n').filter(line => line.trim());
+    const debugLines = debugContent
+      .trim()
+      .split('\n')
+      .filter(line => line.trim());
     expect(debugLines.length).to.be.greaterThan(0);
-    
+
     const debugData = debugLines.map(line => JSON.parse(line));
     const testEntries = debugData.filter(entry => entry.action === 'addTest');
     expect(testEntries.length).to.be.greaterThan(0);
-    
+
     return { stdout, stderr, debugData, testEntries };
   }
 
   describe('Basic Functionality', () => {
     it('should execute tests and generate debug data', async () => {
       const { stdout, debugData, testEntries } = await runCodeceptTest();
-      
+
       // Verify test execution
       expect(stdout).to.include('Simple Tests');
       expect(stdout).to.include('should always pass');
       expect(stdout).to.include('should always fail');
-      
+
       // Should have 1 passed and 1 failed
       expect(stdout).to.match(/1 passed.*1 failed/);
-      
+
       // Verify debug data
       expect(testEntries.length).to.equal(2); // exactly 2 tests
       expect(debugData.length).to.be.greaterThan(0);
@@ -90,11 +93,11 @@ describe('CodeceptJS Adapter Tests', function() {
   describe('Test Execution Results', () => {
     it('should handle both passing and failing tests', async () => {
       const { stdout } = await runCodeceptTest();
-      
+
       // Check for pass/fail indicators
-      expect(stdout).to.include('✔ should always pass');
-      expect(stdout).to.include('✖ should always fail');
-      
+      expect(stdout).to.include('should always pass');
+      expect(stdout).to.include('should always fail');
+
       // Check for failure details
       expect(stdout).to.include('This should fail intentionally');
       expect(stdout).to.include('AssertionError');
@@ -106,16 +109,16 @@ describe('CodeceptJS Adapter Tests', function() {
       // Read the codecept config to verify testomat plugin is configured
       const configPath = path.join(exampleDir, 'codecept.conf.js');
       const configContent = fs.readFileSync(configPath, 'utf-8');
-      
+
       expect(configContent).to.include('testomat');
       expect(configContent).to.include('../../lib/adapter/codecept');
     });
 
     it('should handle TESTOMATIO environment variable', async () => {
       const { stdout } = await runCodeceptTest('simple_test.js', {
-        TESTOMATIO: 'custom-test-key'
+        TESTOMATIO: 'custom-test-key',
       });
-      
+
       // Test should still run (regardless of whether reporting works)
       expect(stdout).to.include('Simple Tests');
     });
@@ -125,9 +128,9 @@ describe('CodeceptJS Adapter Tests', function() {
     it('should have simple test file with correct structure', () => {
       const testFilePath = path.join(exampleDir, 'simple_test.js');
       expect(fs.existsSync(testFilePath)).to.be.true;
-      
+
       const testContent = fs.readFileSync(testFilePath, 'utf-8');
-      expect(testContent).to.include('Feature(\'Simple Tests\')');
+      expect(testContent).to.include("Feature('Simple Tests')");
       expect(testContent).to.include('should always pass');
       expect(testContent).to.include('should always fail');
     });
@@ -135,7 +138,7 @@ describe('CodeceptJS Adapter Tests', function() {
     it('should have package.json configured for CommonJS', () => {
       const packagePath = path.join(exampleDir, 'package.json');
       expect(fs.existsSync(packagePath)).to.be.true;
-      
+
       const packageContent = JSON.parse(fs.readFileSync(packagePath, 'utf-8'));
       expect(packageContent.type).to.equal('commonjs');
     });
@@ -144,18 +147,18 @@ describe('CodeceptJS Adapter Tests', function() {
   describe('Debug Pipe Integration', () => {
     it('should capture test metadata and status', async () => {
       const { testEntries } = await runCodeceptTest();
-      
+
       // Should have exactly 2 tests
       expect(testEntries.length).to.equal(2);
-      
+
       // Find passing and failing tests
       const passingTest = testEntries.find(entry => entry.testId.status === 'passed');
       const failingTest = testEntries.find(entry => entry.testId.status === 'failed');
-      
+
       expect(passingTest).to.exist;
       expect(passingTest.testId.title).to.equal('should always pass');
       expect(passingTest.testId.suite_title).to.equal('Simple Tests');
-      
+
       expect(failingTest).to.exist;
       expect(failingTest.testId.title).to.equal('should always fail');
       expect(failingTest.testId.suite_title).to.equal('Simple Tests');
@@ -164,7 +167,7 @@ describe('CodeceptJS Adapter Tests', function() {
 
     it('should capture test execution metadata', async () => {
       const { testEntries } = await runCodeceptTest();
-      
+
       // Check that all tests have required metadata
       testEntries.forEach(entry => {
         expect(entry.testId).to.exist;
@@ -179,10 +182,10 @@ describe('CodeceptJS Adapter Tests', function() {
 
     it('should handle test failures with proper error information', async () => {
       const { testEntries } = await runCodeceptTest();
-      
+
       const failingTest = testEntries.find(entry => entry.testId.status === 'failed');
       expect(failingTest).to.exist;
-      
+
       // Should have error details
       expect(failingTest.testId.stack).to.include('AssertionError');
       expect(failingTest.testId.stack).to.include('This should fail intentionally');


### PR DESCRIPTION
- Added check for existing file extensions before appending based on content type.
- Improved extension mapping for 'jpeg' to 'jpg' and added support for 'plain' to 'txt'.