### PR TITLE
DRAFT: [COVERAGE REPORTER TASK] Expand start-test comand by coverage-mode

### DIFF
--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -15,6 +15,12 @@ import { filesize as prettyBytes } from 'filesize';
 import dotenv from 'dotenv';
 import Replay from '../replay.js';
 
+// coverage option imports
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+import yaml from 'js-yaml';
+
 const debug = createDebugMessages('@testomatio/reporter:xml-cli');
 const version = getPackageVersion();
 console.log(pc.cyan(pc.bold(` 🤩 Testomat.io Reporter v${version}`)));
@@ -69,6 +75,188 @@ program
       process.exit(0);
     });
   });
+
+program
+  .command('run')
+  .alias('coverage')
+  .description('Run tests by the specified coverage file')
+  .argument('<command>', 'Test runner command')
+  .option('--coverage <filename>', 'Test Coverage Execution based on the relates GIT changes')
+  .action(async (command, opts) => {
+    const { coverage } = opts;
+
+    const apiKey = process.env['INPUT_TESTOMATIO-KEY'] || config.TESTOMATIO;
+    const formattedDate = new Date().toISOString().replace(/T/, '-').replace(/:/g, '-').split('.')[0];
+    const title = process.env.TESTOMATIO_TITLE || `Test Coverage Execution - ${formattedDate}`;
+
+    if (!command || !command.split) {
+      console.log(APP_PREFIX, `No command provided. Use -c option to launch a test runner.`);
+      return process.exit(255);
+    }
+
+    const client = new TestomatClient({ apiKey, title, parallel: true });
+
+    // TODO: Think about a separate pipe for coverage
+    if (coverage) {
+      // Check if the coverage file path actually exists on the filesystem
+      // TODO: All operation to coverage file -> to separate coverage-pipe.js
+      if (!fs.existsSync(coverage)) {
+        console.log('❌ Coverage file not found:', coverage);
+        return;
+      }
+
+      // Ensure the given path is a file (not a directory or other type)
+      const stat = fs.statSync(coverage);
+      if (!stat.isFile()) {
+        console.log('❌ Provided coverage path is not a file:', coverage);
+        return;
+      }
+
+      // Validate the file extension to be ".yml" to ensure it's a YAML file
+      if (path.extname(coverage) !== ".yml") {
+        console.log('❌ Coverage file must have a .yml extension:', coverage);
+        return;
+      }
+
+      let parsedCoverage, changedFiles;
+
+      try {
+        // Read the contents of the YAML file and attempt to parse the YAML into a JavaScript object
+        const rawYml = fs.readFileSync(coverage, 'utf8');
+        parsedCoverage = yaml.load(rawYml);
+      } 
+      catch (e) {
+        console.error('❌ Failed to parse YAML:', e.message);
+        return;
+      }
+
+      // Step 1: Get Git changed files
+      // TODO: Next step: in future we can switch to get diff between master (or any stable branch) with current branch
+      try {
+        changedFiles = execSync('git diff --name-only', { encoding: 'utf-8' })
+          .split('\n')
+          .filter(Boolean);
+      } 
+      catch (err) {
+        console.error('❌ Failed to get git changed files:', err.message);
+        return;
+      }
+
+      // Step 2: Prepare coverage file test IDs
+      const tests = new Set();
+      const suiteIds = new Set();
+      const tagLabels = new Set();
+      // TODO: for future updates: by label, plan...
+      // const labels = new Set();
+
+      const coverageEntries = parsedCoverage.files || {};
+      const matchedLines = new Set(); //TODO: need to check by changed file folder like "app/db" NOT be file "app/db/user.db"
+
+      changedFiles.forEach(changedFile => {
+        for (const [pattern, ids] of Object.entries(coverageEntries)) {
+          const normalizedPattern = pattern.replace('*', ''); //TODO:: sweatch to get all subfolder/subfile list???
+          if (changedFile.startsWith(normalizedPattern)) {
+            matchedLines.add(changedFile);
+            ids.forEach(id => {
+              // Example: "@Tt74099t1"
+              if (id.startsWith('@T')) {
+                tests.add(id.slice(2));
+              } 
+              // Example: "@Sd74099c1"
+              else if (id.startsWith('@S')) {
+                suiteIds.add(id.slice(2));
+              }
+              // Example: "tag:@TestSmoke"
+              else if (id.startsWith('tag')) {
+                tagLabels.add(id.split(':')[1].slice(1));
+              }
+            });
+          }
+        }
+      });
+
+      if (matchedLines.size === 0) {
+        console.log('ℹ️ Your config does not have corresponding lines for current Git changes.');
+        return;
+      }
+
+      // Step 3.1: Resolve tag test IDs via server
+      try { //TODO: move to a separate function to avoid duplication for each type of pipeOptions
+        const tagPromises = [...tagLabels].map(tag =>
+          client.prepareRun({ pipe: "testomatio", pipeOptions: `tag-name=${tag}` }) // OR use as in filter: tag-name=smoke
+            .then(tagTests => {
+              if (Array.isArray(tagTests) && tagTests.length > 0) {
+                tagTests.forEach(testId => tests.add(testId));
+              }
+              else {
+                console.log(APP_PREFIX, `🔍 No test by tag-name=${tag} were found on the server side`);
+              }
+            })
+        );
+      
+        await Promise.all(tagPromises);
+      } 
+      catch (err) {
+        console.log(APP_PREFIX, `❌ Failed to retrieve the list of TAGGED tests: ${err}`);
+      }
+
+      // // Step 3.2: Resolve suite test IDs via server
+      // // TODO: need to double-check on the server side!!! by server code
+      // I found this list of types = ['tag-name', 'plan', 'label', 'jira-ticket'];
+      // try {
+      //   const suitePromises = [...suiteIds].map(suiteId =>
+      //     client.prepareRun({ pipe: "testomatio", pipeOptions: `suite=${suiteId}` }) //TODO: if suite= can be parsed by server???
+      //       .then(suiteTests => {
+      //         if (Array.isArray(suiteTests) && suiteTests.length > 0) {
+      //           suiteTests.forEach(testId => tests.add(testId));
+      //         }
+      //         else {
+      //           console.log(APP_PREFIX, `🔍 No tests by suite=${suiteId} were found on the server side`);
+      //         }
+      //       })
+      //   );
+      
+      //   await Promise.all(suitePromises);
+      // } 
+      // catch (err) {
+      //   console.log(APP_PREFIX, `❌ Failed to retrieve the list of SUITE's tests: ${err}`);
+      // }
+
+      if (tests.size > 0) {
+        command += ` --grep (${[...tests].join('|')})`;
+      }
+      else {
+        console.log(APP_PREFIX, pc.green('Sorry: 🔍 No tests were found to execute by your git/coverage request!'));
+        return;
+      }
+    }
+
+    console.log(APP_PREFIX, `🚀 Running`, pc.green(command)); // TODO: in this case need to test "command" variable
+    console.log("Debug command text:", command.split(' ')); // TODO: in this case need to test "command" variable
+
+    // TODO: uncomment after first phase testing!!!
+    // const runTests = async () => { //TODO: move to a separate function to avoid code duplication vs --filter case???
+    //   const testCmds = command.split(' ');
+    //   const cmd = spawn(testCmds[0], testCmds.slice(1), { stdio: 'inherit' });
+
+    //   cmd.on('close', async code => {
+    //     const emoji = code === 0 ? '🟢' : '🔴';
+    //     console.log(APP_PREFIX, emoji, `Runner exited with ${pc.bold(code)}`);
+    //     if (apiKey) {
+    //       const status = code === 0 ? 'passed' : 'failed';
+    //       await client.updateRunStatus(status, true);
+    //     }
+    //     process.exit(code);
+    //   });
+    // };
+
+    // if (apiKey) {
+    //   await client.createRun().then(runTests);
+    // } else {
+    //   await runTests(); //TODO: why we use this code???
+    // }
+  }
+);
 
 program
   .command('run')

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -77,7 +77,7 @@ program
   });
 
 program
-  .command('run')
+  .command('run-coverage')
   .alias('coverage')
   .description('Run tests by the specified coverage file')
   .argument('<command>', 'Test runner command')
@@ -97,59 +97,87 @@ program
     const client = new TestomatClient({ apiKey, title, parallel: true });
 
     // TODO: Think about a separate pipe for coverage
+    // TODO: All operation to coverage file -> to separate coverage-pipe.js
     if (coverage) {
-      // Check if the coverage file path actually exists on the filesystem
-      // TODO: All operation to coverage file -> to separate coverage-pipe.js
-      if (!fs.existsSync(coverage)) {
-        console.log('❌ Coverage file not found:', coverage);
-        return;
-      }
+      // Example: 'filepath:coverage.yml,branch:master'
+      const options = Object.fromEntries(
+        coverage
+          .split(',')                          // example: [ 'filepath:coverage.yml', 'branch:master' ]
+          .map(option => option.split(':'))    // example: [key, value]
+      );
 
-      // Ensure the given path is a file (not a directory or other type)
-      const stat = fs.statSync(coverage);
-      if (!stat.isFile()) {
-        console.log('❌ Provided coverage path is not a file:', coverage);
-        return;
-      }
-
-      // Validate the file extension to be ".yml" to ensure it's a YAML file
-      if (path.extname(coverage) !== ".yml") {
-        console.log('❌ Coverage file must have a .yml extension:', coverage);
-        return;
-      }
-
-      let parsedCoverage, changedFiles;
-
-      try {
-        // Read the contents of the YAML file and attempt to parse the YAML into a JavaScript object
-        const rawYml = fs.readFileSync(coverage, 'utf8');
-        parsedCoverage = yaml.load(rawYml);
-      } 
-      catch (e) {
-        console.error('❌ Failed to parse YAML:', e.message);
-        return;
-      }
+      const { filepath: coverageFilePath } = options
+      let parsedCoverage, changedFiles;      
 
       // Step 1: Get Git changed files
       // TODO: Next step: in future we can switch to get diff between master (or any stable branch) with current branch
+      // => if changedFiles = empty list -> log(current brunch don't have any changed files) - for now!
       try {
-        changedFiles = execSync('git diff --name-only', { encoding: 'utf-8' })
+        changedFiles = execSync('git diff --name-only', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] })
           .split('\n')
           .filter(Boolean);
       } 
       catch (err) {
-        console.error('❌ Failed to get git changed files:', err.message);
+        const errorMessage = err.message || '';
+        // Git edge case-1: Not a git repository or other error
+        if (errorMessage.includes('Not a git repository')) {
+          console.error(APP_PREFIX, '❌ Error: This folder is not a Git repository.');
+        }
+        else {
+          console.error(APP_PREFIX, '❌ Failed to get Git changed files:', errorMessage);
+        }
+
         return;
       }
 
-      // Step 2: Prepare coverage file test IDs
+      // Git edge case-2: No git diff changed files
+      if (changedFiles.length === 0) {
+        console.log(APP_PREFIX, 'ℹ️ No Git changed files detected. Skipping coverage processing.');
+        return;
+      }
+
+      console.log(APP_PREFIX, `📑 GIT changed files:\n  - ${changedFiles.join('\n  - ')}`);
+
+      // Step 2: Check if the coverage file path actually exists on the filesystem
+      // Validate the presence of the coverage filepath
+      if (!coverageFilePath || !fs.existsSync(coverageFilePath)) {
+        console.log(APP_PREFIX, '❌ Coverage file not found:', coverageFilePath);
+        return;
+      }
+
+      // Ensure the given path is a file (not a directory or other type)
+      const stat = fs.statSync(coverageFilePath);
+      if (!stat.isFile()) {
+        console.log(APP_PREFIX, '❌ Provided coverage path is not a file:', coverageFilePath);
+        return;
+      }
+
+      // Validate the file extension to be ".yml" to ensure it's a YAML file
+      if (path.extname(coverageFilePath) !== ".yml") {
+        console.log(APP_PREFIX, '❌ Coverage file must have a .yml extension:', coverageFilePath);
+        return;
+      }
+
+      try {
+        // Read the contents of the YAML file and attempt to parse the YAML into a JavaScript object
+        const rawYml = fs.readFileSync(coverageFilePath, 'utf8');
+        parsedCoverage = yaml.load(rawYml);
+      } 
+      catch (e) {
+        console.error(APP_PREFIX, '❌ Failed to parse YAML:', e.message);
+        return;
+      }
+
+      console.log(APP_PREFIX, '✅ Coverage file found at:', coverageFilePath);
+
+      // Step 3: Prepare coverage test IDs
       const tests = new Set();
       const suiteIds = new Set();
       const tagLabels = new Set();
-      // TODO: for future updates: by label, plan...
-      // const labels = new Set();
 
-      const coverageEntries = parsedCoverage.files || {};
+      // const coverageEntries = parsedCoverage.files || {}; OLD version???
+      const coverageEntries = parsedCoverage || {};
+
       const matchedLines = new Set(); //TODO: need to check by changed file folder like "app/db" NOT be file "app/db/user.db"
 
       changedFiles.forEach(changedFile => {
@@ -160,11 +188,11 @@ program
             ids.forEach(id => {
               // Example: "@Tt74099t1"
               if (id.startsWith('@T')) {
-                tests.add(id.slice(2));
+                tests.add(id.slice(1));
               } 
               // Example: "@Sd74099c1"
               else if (id.startsWith('@S')) {
-                suiteIds.add(id.slice(2));
+                suiteIds.add(id.slice(2)); //TODO: without "S"???
               }
               // Example: "tag:@TestSmoke"
               else if (id.startsWith('tag')) {
@@ -176,7 +204,7 @@ program
       });
 
       if (matchedLines.size === 0) {
-        console.log('ℹ️ Your config does not have corresponding lines for current Git changes.');
+        console.log(APP_PREFIX, 'ℹ️ Your config does not have corresponding lines for current Git changes.');
         return;
       }
 
@@ -200,27 +228,25 @@ program
         console.log(APP_PREFIX, `❌ Failed to retrieve the list of TAGGED tests: ${err}`);
       }
 
-      // // Step 3.2: Resolve suite test IDs via server
-      // // TODO: need to double-check on the server side!!! by server code
-      // I found this list of types = ['tag-name', 'plan', 'label', 'jira-ticket'];
-      // try {
-      //   const suitePromises = [...suiteIds].map(suiteId =>
-      //     client.prepareRun({ pipe: "testomatio", pipeOptions: `suite=${suiteId}` }) //TODO: if suite= can be parsed by server???
-      //       .then(suiteTests => {
-      //         if (Array.isArray(suiteTests) && suiteTests.length > 0) {
-      //           suiteTests.forEach(testId => tests.add(testId));
-      //         }
-      //         else {
-      //           console.log(APP_PREFIX, `🔍 No tests by suite=${suiteId} were found on the server side`);
-      //         }
-      //       })
-      //   );
+      // Step 3.2: Resolve suite test IDs via server
+      try {
+        const suitePromises = [...suiteIds].map(suiteId =>
+          client.prepareRun({ pipe: "testomatio", pipeOptions: `suite=${suiteId}` }) //TODO: if suite= can be parsed by server???
+            .then(suiteTests => {
+              if (Array.isArray(suiteTests) && suiteTests.length > 0) {
+                suiteTests.forEach(testId => tests.add(testId));
+              }
+              else {
+                console.log(APP_PREFIX, `🔍 No tests by suite=${suiteId} were found on the server side`);
+              }
+            })
+        );
       
-      //   await Promise.all(suitePromises);
-      // } 
-      // catch (err) {
-      //   console.log(APP_PREFIX, `❌ Failed to retrieve the list of SUITE's tests: ${err}`);
-      // }
+        await Promise.all(suitePromises);
+      } 
+      catch (err) {
+        console.log(APP_PREFIX, `❌ Failed to retrieve the list of SUITE's tests: ${err}`);
+      }
 
       if (tests.size > 0) {
         command += ` --grep (${[...tests].join('|')})`;
@@ -232,7 +258,7 @@ program
     }
 
     console.log(APP_PREFIX, `🚀 Running`, pc.green(command)); // TODO: in this case need to test "command" variable
-    console.log("Debug command text:", command.split(' ')); // TODO: in this case need to test "command" variable
+    console.log("Debug command text:", command.split(' ')); // TODO: REMOVE after testingin this case need to test "command" variable
 
     // TODO: uncomment after first phase testing!!!
     // const runTests = async () => { //TODO: move to a separate function to avoid code duplication vs --filter case???
@@ -281,6 +307,7 @@ program
 
       try {
         const tests = await client.prepareRun({ pipe, pipeOptions });
+        // TODO: add case if NO tests found -> return; ???
         if (tests && tests.length > 0) {
           command += ` --grep (${tests.join('|')})`;
         }
@@ -291,26 +318,26 @@ program
 
     console.log(APP_PREFIX, `🚀 Running`, pc.green(command));
 
-    const runTests = async () => {
-      const testCmds = command.split(' ');
-      const cmd = spawn(testCmds[0], testCmds.slice(1), { stdio: 'inherit' });
+    // const runTests = async () => {
+    //   const testCmds = command.split(' ');
+    //   const cmd = spawn(testCmds[0], testCmds.slice(1), { stdio: 'inherit' });
 
-      cmd.on('close', async code => {
-        const emoji = code === 0 ? '🟢' : '🔴';
-        console.log(APP_PREFIX, emoji, `Runner exited with ${pc.bold(code)}`);
-        if (apiKey) {
-          const status = code === 0 ? 'passed' : 'failed';
-          await client.updateRunStatus(status, true);
-        }
-        process.exit(code);
-      });
-    };
+    //   cmd.on('close', async code => {
+    //     const emoji = code === 0 ? '🟢' : '🔴';
+    //     console.log(APP_PREFIX, emoji, `Runner exited with ${pc.bold(code)}`);
+    //     if (apiKey) {
+    //       const status = code === 0 ? 'passed' : 'failed';
+    //       await client.updateRunStatus(status, true);
+    //     }
+    //     process.exit(code);
+    //   });
+    // };
 
-    if (apiKey) {
-      await client.createRun().then(runTests);
-    } else {
-      await runTests();
-    }
+    // if (apiKey) {
+    //   await client.createRun().then(runTests);
+    // } else {
+    //   await runTests();
+    // }
   });
 
 // program

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -72,24 +72,42 @@ program
   });
 
 program
-  .command('run-coverage')
-  .alias('coverage')
-  .description('Run tests by the specified coverage file')
+  .command('run')
+  .alias('test')
+  .description('Run tests with the specified command')
   .argument('<command>', 'Test runner command')
+  .option('--filter <filter>', 'Additional execution filter')
   .option('--coverage <filename>', 'Test Coverage Execution based on the relates GIT changes')
   .action(async (command, opts) => {
-    const { coverage } = opts;
     const apiKey = process.env['INPUT_TESTOMATIO-KEY'] || config.TESTOMATIO;
-    const title = process.env.TESTOMATIO_TITLE;
+    const formattedDate = new Date().toISOString().replace(/T/, '-').replace(/:/g, '-').split('.')[0];
+    const title = process.env.TESTOMATIO_TITLE || `Test Coverage Execution - ${formattedDate}`;
+
+    const { coverage, filter } = opts;
 
     if (!command || !command.split) {
       console.log(APP_PREFIX, `No command provided. Use -c option to launch a test runner.`);
       return process.exit(255);
     }
 
-    // TODO: Think about a separate pipe for coverage
-    // TODO: All operation to coverage file -> to separate coverage-pipe.js
-    if (coverage) {
+    const client = new TestomatClient({ apiKey, title, parallel: true });
+
+    if (filter) {
+      const [pipe, ...optsArray] = filter.split(':');
+      const pipeOptions = optsArray.join(':');
+
+      try {
+        const tests = await client.prepareRun({ pipe, pipeOptions });
+        // TODO: add case if NO tests found -> return; ???
+        if (tests && tests.length > 0) {
+          command += ` --grep (${tests.join('|')})`;
+        }
+      } catch (err) {
+        console.log(APP_PREFIX, err);
+      }
+    }
+
+    if (coverage) {      
       // Example: 'filepath:coverage.yml,branch:master'
       const options = Object.fromEntries(
         coverage
@@ -100,8 +118,7 @@ program
       try {
         const coverage = new Coverage({
           filepath: options.filepath,
-          apiKey,
-          title
+          client
         });
 
         // Step 1: Get Git changed files
@@ -125,88 +142,30 @@ program
       }
     }
 
-    console.log(APP_PREFIX, `🚀 Running`, pc.green(command)); // TODO: in this case need to test "command" variable
-    console.log("Debug command text:", command.split(' ')); // TODO: REMOVE after testing in this case need to test "command" variable
+    console.log(APP_PREFIX, `🚀 Running`, pc.green(command));
+    //TODO: Coverage Task - Step-1: finish in this place -> Next step => double check execute command by suite,tag,test_ids
     debug("Full command text:", command.split(' '));
 
-    // TODO: uncomment after first phase testing!!!
-    // const runTests = async () => { //TODO: move to a separate function to avoid code duplication vs --filter case???
-    //   const testCmds = command.split(' ');
-    //   const cmd = spawn(testCmds[0], testCmds.slice(1), { stdio: 'inherit' });
+    const runTests = async () => {
+      const testCmds = command.split(' ');
+      const cmd = spawn(testCmds[0], testCmds.slice(1), { stdio: 'inherit' });
 
-    //   cmd.on('close', async code => {
-    //     const emoji = code === 0 ? '🟢' : '🔴';
-    //     console.log(APP_PREFIX, emoji, `Runner exited with ${pc.bold(code)}`);
-    //     if (apiKey) {
-    //       const status = code === 0 ? 'passed' : 'failed';
-    //       await client.updateRunStatus(status, true);
-    //     }
-    //     process.exit(code);
-    //   });
-    // };
-
-    // if (apiKey) {
-    //   await client.createRun().then(runTests);
-    // } else {
-    //   await runTests(); //TODO: why we use this code???
-    // }
-  }
-);
-
-program
-  .command('run')
-  .alias('test')
-  .description('Run tests with the specified command')
-  .argument('<command>', 'Test runner command')
-  .option('--filter <filter>', 'Additional execution filter')
-  .action(async (command, opts) => {
-    const apiKey = process.env['INPUT_TESTOMATIO-KEY'] || config.TESTOMATIO;
-    const title = process.env.TESTOMATIO_TITLE;
-
-    if (!command || !command.split) {
-      console.log(APP_PREFIX, `No command provided. Use -c option to launch a test runner.`);
-      return process.exit(255);
-    }
-
-    const client = new TestomatClient({ apiKey, title, parallel: true });
-
-    if (opts.filter) {
-      const [pipe, ...optsArray] = opts.filter.split(':');
-      const pipeOptions = optsArray.join(':');
-
-      try {
-        const tests = await client.prepareRun({ pipe, pipeOptions });
-        // TODO: add case if NO tests found -> return; ???
-        if (tests && tests.length > 0) {
-          command += ` --grep (${tests.join('|')})`;
+      cmd.on('close', async code => {
+        const emoji = code === 0 ? '🟢' : '🔴';
+        console.log(APP_PREFIX, emoji, `Runner exited with ${pc.bold(code)}`);
+        if (apiKey) {
+          const status = code === 0 ? 'passed' : 'failed';
+          await client.updateRunStatus(status, true);
         }
-      } catch (err) {
-        console.log(APP_PREFIX, err);
-      }
+        process.exit(code);
+      });
+    };
+
+    if (apiKey) {
+      await client.createRun().then(runTests);
+    } else {
+      await runTests();
     }
-
-    console.log(APP_PREFIX, `🚀 Running`, pc.green(command));
-
-    // const runTests = async () => {
-    //   const testCmds = command.split(' ');
-    //   const cmd = spawn(testCmds[0], testCmds.slice(1), { stdio: 'inherit' });
-
-    //   cmd.on('close', async code => {
-    //     const emoji = code === 0 ? '🟢' : '🔴';
-    //     console.log(APP_PREFIX, emoji, `Runner exited with ${pc.bold(code)}`);
-    //     if (apiKey) {
-    //       const status = code === 0 ? 'passed' : 'failed';
-    //       await client.updateRunStatus(status, true);
-    //     }
-    //     process.exit(code);
-    //   });
-    // };
-
-    // if (apiKey) {
-    //   await client.createRun().then(runTests);
-    // } else {
-    //   await runTests();
-    // }
   });
 
 // program

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -81,7 +81,7 @@ program
   .action(async (command, opts) => {
     const apiKey = process.env['INPUT_TESTOMATIO-KEY'] || config.TESTOMATIO;
     const formattedDate = new Date().toISOString().replace(/T/, '-').replace(/:/g, '-').split('.')[0];
-    const title = process.env.TESTOMATIO_TITLE || `Test Coverage Execution - ${formattedDate}`;
+    const title = process.env.TESTOMATIO_TITLE || `Testomatio Test Execution - ${formattedDate}`;
 
     const { coverage, filter } = opts;
 

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -5,6 +5,7 @@ import { spawn } from 'cross-spawn';
 import { glob } from 'glob';
 import createDebugMessages from 'debug';
 import TestomatClient from '../client.js';
+import Coverage from '../coverage.js';
 import XmlReader from '../xmlReader.js';
 import { APP_PREFIX, STATUS } from '../constants.js';
 import { cleanLatestRunId, getPackageVersion } from '../utils/utils.js';
@@ -14,12 +15,6 @@ import pc from 'picocolors';
 import { filesize as prettyBytes } from 'filesize';
 import dotenv from 'dotenv';
 import Replay from '../replay.js';
-
-// coverage option imports
-import fs from 'fs';
-import path from 'path';
-import { execSync } from 'child_process';
-import yaml from 'js-yaml';
 
 const debug = createDebugMessages('@testomatio/reporter:xml-cli');
 const version = getPackageVersion();
@@ -84,17 +79,13 @@ program
   .option('--coverage <filename>', 'Test Coverage Execution based on the relates GIT changes')
   .action(async (command, opts) => {
     const { coverage } = opts;
-
     const apiKey = process.env['INPUT_TESTOMATIO-KEY'] || config.TESTOMATIO;
-    const formattedDate = new Date().toISOString().replace(/T/, '-').replace(/:/g, '-').split('.')[0];
-    const title = process.env.TESTOMATIO_TITLE || `Test Coverage Execution - ${formattedDate}`;
+    const title = process.env.TESTOMATIO_TITLE;
 
     if (!command || !command.split) {
       console.log(APP_PREFIX, `No command provided. Use -c option to launch a test runner.`);
       return process.exit(255);
     }
-
-    const client = new TestomatClient({ apiKey, title, parallel: true });
 
     // TODO: Think about a separate pipe for coverage
     // TODO: All operation to coverage file -> to separate coverage-pipe.js
@@ -106,159 +97,37 @@ program
           .map(option => option.split(':'))    // example: [key, value]
       );
 
-      const { filepath: coverageFilePath } = options
-      let parsedCoverage, changedFiles;      
-
-      // Step 1: Get Git changed files
-      // TODO: Next step: in future we can switch to get diff between master (or any stable branch) with current branch
-      // => if changedFiles = empty list -> log(current brunch don't have any changed files) - for now!
       try {
-        changedFiles = execSync('git diff --name-only', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] })
-          .split('\n')
-          .filter(Boolean);
-      } 
+        const coverage = new Coverage({
+          filepath: options.filepath,
+          apiKey,
+          title
+        });
+
+        // Step 1: Get Git changed files
+        if (!coverage.getChangedFiles()) return;
+        // Step 2: Validate coverage file path
+        if (!coverage.validateCoverageFile()) return;
+        // Step 3: Parse coverage file
+        if (!coverage.parseCoverageFile()) return;
+        // Step 4: Prepare coverage test IDs
+        if (!coverage.extractRelevantTestIds()) return;
+
+        await coverage.resolveTestIdsFromAttributes(); //TODO: const {test, tag, label } = await coverage.resolveTestIdsFromAttributes(); ???
+        const grep = coverage.getGrepCommand();
+
+        if (!grep) return;
+
+        command += grep;
+      }
       catch (err) {
-        const errorMessage = err.message || '';
-        // Git edge case-1: Not a git repository or other error
-        if (errorMessage.includes('Not a git repository')) {
-          console.error(APP_PREFIX, '❌ Error: This folder is not a Git repository.');
-        }
-        else {
-          console.error(APP_PREFIX, '❌ Failed to get Git changed files:', errorMessage);
-        }
-
-        return;
-      }
-
-      // Git edge case-2: No git diff changed files
-      if (changedFiles.length === 0) {
-        console.log(APP_PREFIX, 'ℹ️ No Git changed files detected. Skipping coverage processing.');
-        return;
-      }
-
-      console.log(APP_PREFIX, `📑 GIT changed files:\n  - ${changedFiles.join('\n  - ')}`);
-
-      // Step 2: Check if the coverage file path actually exists on the filesystem
-      // Validate the presence of the coverage filepath
-      if (!coverageFilePath || !fs.existsSync(coverageFilePath)) {
-        console.log(APP_PREFIX, '❌ Coverage file not found:', coverageFilePath);
-        return;
-      }
-
-      // Ensure the given path is a file (not a directory or other type)
-      const stat = fs.statSync(coverageFilePath);
-      if (!stat.isFile()) {
-        console.log(APP_PREFIX, '❌ Provided coverage path is not a file:', coverageFilePath);
-        return;
-      }
-
-      // Validate the file extension to be ".yml" to ensure it's a YAML file
-      if (path.extname(coverageFilePath) !== ".yml") {
-        console.log(APP_PREFIX, '❌ Coverage file must have a .yml extension:', coverageFilePath);
-        return;
-      }
-
-      try {
-        // Read the contents of the YAML file and attempt to parse the YAML into a JavaScript object
-        const rawYml = fs.readFileSync(coverageFilePath, 'utf8');
-        parsedCoverage = yaml.load(rawYml);
-      } 
-      catch (e) {
-        console.error(APP_PREFIX, '❌ Failed to parse YAML:', e.message);
-        return;
-      }
-
-      console.log(APP_PREFIX, '✅ Coverage file found at:', coverageFilePath);
-
-      // Step 3: Prepare coverage test IDs
-      const tests = new Set();
-      const suiteIds = new Set();
-      const tagLabels = new Set();
-
-      // const coverageEntries = parsedCoverage.files || {}; OLD version???
-      const coverageEntries = parsedCoverage || {};
-
-      const matchedLines = new Set(); //TODO: need to check by changed file folder like "app/db" NOT be file "app/db/user.db"
-
-      changedFiles.forEach(changedFile => {
-        for (const [pattern, ids] of Object.entries(coverageEntries)) {
-          const normalizedPattern = pattern.replace('*', ''); //TODO:: sweatch to get all subfolder/subfile list???
-          if (changedFile.startsWith(normalizedPattern)) {
-            matchedLines.add(changedFile);
-            ids.forEach(id => {
-              // Example: "@Tt74099t1"
-              if (id.startsWith('@T')) {
-                tests.add(id.slice(1));
-              } 
-              // Example: "@Sd74099c1"
-              else if (id.startsWith('@S')) {
-                suiteIds.add(id.slice(2)); //TODO: without "S"???
-              }
-              // Example: "tag:@TestSmoke"
-              else if (id.startsWith('tag')) {
-                tagLabels.add(id.split(':')[1].slice(1));
-              }
-            });
-          }
-        }
-      });
-
-      if (matchedLines.size === 0) {
-        console.log(APP_PREFIX, 'ℹ️ Your config does not have corresponding lines for current Git changes.');
-        return;
-      }
-
-      // Step 3.1: Resolve tag test IDs via server
-      try { //TODO: move to a separate function to avoid duplication for each type of pipeOptions
-        const tagPromises = [...tagLabels].map(tag =>
-          client.prepareRun({ pipe: "testomatio", pipeOptions: `tag-name=${tag}` }) // OR use as in filter: tag-name=smoke
-            .then(tagTests => {
-              if (Array.isArray(tagTests) && tagTests.length > 0) {
-                tagTests.forEach(testId => tests.add(testId));
-              }
-              else {
-                console.log(APP_PREFIX, `🔍 No test by tag-name=${tag} were found on the server side`);
-              }
-            })
-        );
-      
-        await Promise.all(tagPromises);
-      } 
-      catch (err) {
-        console.log(APP_PREFIX, `❌ Failed to retrieve the list of TAGGED tests: ${err}`);
-      }
-
-      // Step 3.2: Resolve suite test IDs via server
-      try {
-        const suitePromises = [...suiteIds].map(suiteId =>
-          client.prepareRun({ pipe: "testomatio", pipeOptions: `suite=${suiteId}` }) //TODO: if suite= can be parsed by server???
-            .then(suiteTests => {
-              if (Array.isArray(suiteTests) && suiteTests.length > 0) {
-                suiteTests.forEach(testId => tests.add(testId));
-              }
-              else {
-                console.log(APP_PREFIX, `🔍 No tests by suite=${suiteId} were found on the server side`);
-              }
-            })
-        );
-      
-        await Promise.all(suitePromises);
-      } 
-      catch (err) {
-        console.log(APP_PREFIX, `❌ Failed to retrieve the list of SUITE's tests: ${err}`);
-      }
-
-      if (tests.size > 0) {
-        command += ` --grep (${[...tests].join('|')})`;
-      }
-      else {
-        console.log(APP_PREFIX, pc.green('Sorry: 🔍 No tests were found to execute by your git/coverage request!'));
-        return;
+        console.error(APP_PREFIX, '❌ Coverage execution failed:', err.message);
       }
     }
 
     console.log(APP_PREFIX, `🚀 Running`, pc.green(command)); // TODO: in this case need to test "command" variable
-    console.log("Debug command text:", command.split(' ')); // TODO: REMOVE after testingin this case need to test "command" variable
+    console.log("Debug command text:", command.split(' ')); // TODO: REMOVE after testing in this case need to test "command" variable
+    debug("Full command text:", command.split(' '));
 
     // TODO: uncomment after first phase testing!!!
     // const runTests = async () => { //TODO: move to a separate function to avoid code duplication vs --filter case???

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -97,6 +97,7 @@ program
       const pipeOptions = optsArray.join(':');
 
       try {
+        // TODO: move to separate class Filter???
         const tests = await client.prepareRun({ pipe, pipeOptions });
         // TODO: add case if NO tests found -> return; ???
         if (tests && tests.length > 0) {
@@ -108,42 +109,35 @@ program
     }
 
     if (coverage) {      
-      // Example: 'filepath:coverage.yml,branch:master'
+      // Example: 'filepath:coverage.yml,changes:committed' - [changes options: "committed" or "uncommitted"]
       const options = Object.fromEntries(
         coverage
-          .split(',')                          // example: [ 'filepath:coverage.yml', 'branch:master' ]
-          .map(option => option.split(':'))    // example: [key, value]
+          .split(',')                          // example: [ 'filepath:coverage.yml', 'changes:commited' ]
+          .map(option => option.split(':').map(part => part.trim()))    // as [key, value]
+          .filter(([key, val]) => key && val) // => { filepath: 'coverage.yml', changes: 'committed' }
       );
 
       try {
         const coverage = new Coverage({
-          filepath: options.filepath,
+          filepath: options?.filepath,
+          changes: options?.changes,
           client
         });
 
-        // Step 1: Get Git changed files
-        if (!coverage.getChangedFiles()) return;
-        // Step 2: Validate coverage file path
-        if (!coverage.validateCoverageFile()) return;
-        // Step 3: Parse coverage file
-        if (!coverage.parseCoverageFile()) return;
-        // Step 4: Prepare coverage test IDs
-        if (!coverage.extractRelevantTestIds()) return;
-
-        await coverage.resolveTestIdsFromAttributes(); //TODO: const {test, tag, label } = await coverage.resolveTestIdsFromAttributes(); ???
+        // Step 1: Get Git changed files & Validate coverage file path & Parse coverage file
+        if (!coverage.getGitChangedFiles()?.validateCoverageFile()?.parseCoverageFile()) return;
+        // Step 2: Extract relevant tests from selected Git changes
+        if (!await coverage.extractRelevantTestsFromChanges()) return;             
+        // Step 3: Get grep command by list of provided tests
         const grep = coverage.getGrepCommand();
-
-        if (!grep) return;
-
         command += grep;
       }
       catch (err) {
-        console.error(APP_PREFIX, '❌ Coverage execution failed:', err.message);
+        console.error(APP_PREFIX, '❌ Error during coverage processing:', err.message);
       }
     }
 
     console.log(APP_PREFIX, `🚀 Running`, pc.green(command));
-    //TODO: Coverage Task - Step-1: finish in this place -> Next step => double check execute command by suite,tag,test_ids
     debug("Full command text:", command.split(' '));
 
     const runTests = async () => {

--- a/src/coverage.js
+++ b/src/coverage.js
@@ -9,9 +9,20 @@ import { APP_PREFIX } from './constants.js';
 
 const debug = createDebugMessages('@testomatio/reporter:coverage');
 
+// Example of use 'changes:uncommitted' & 'changes:committed-1' part:
+// | Option | Git command |
+// | --- | --- |
+// | uncommitted | ✅ git diff --name-only |
+// | committed | ✅ git show --name-only --pretty="" HEAD |
+// | committed-2 | ✅ git show --name-only --pretty="" HEAD~2 |
+// | committed-0 | ❌ Error: N must be between 1 and 10 |
+// | committed-11 | ❌ Error: N must be between 1 and 10 |
+// | committed-abc | ❌ Error: Invalid format |
+// | committed-@ | ❌ Error: Invalid format |
+// | random | ❌ Error: Invalid changes option |
+
 export default class Coverage {
     #GIT_COMMANDS = {
-        committed: 'git show --name-only --pretty="" HEAD', //TODO: by number of commits like HEAD~3 ???
         uncommitted: 'git diff --name-only'
     };
     #GIT_DEFAULT_MARKER = 'uncommitted';
@@ -56,8 +67,9 @@ export default class Coverage {
             // Git edge: Not a git repository or other error
             if (errorMessage.includes('Not a git repository')) {
                 console.error(APP_PREFIX, '❌ Error: This folder is not a Git repository.');
-            } else {
-                console.error(APP_PREFIX, `❌ Git command failed ("${cmd}"):\n`, errorMessage);
+            } 
+            else {
+                throw new Error(`❌ Git command failed ("${cmd}"):\n`, errorMessage);
             }
     
             return [];
@@ -65,28 +77,82 @@ export default class Coverage {
     }
 
     /**
+     * Dynamically guild the Git command based on `this.changesOption`
+     * 
+     * Supports:
+     * - "uncommitted" => git diff --name-only
+     * - "committed" => git show --name-only --pretty="" HEAD
+     * - "committed-N" (N = 1..10) => git show --name-only --pretty="" HEAD~N
+     * 
+     * Throws an error for:
+     * - Invalid formats like "committed-@", "committed-abc", "committed-11", "committed-0",
+     * - Any `committed-N` where N > 10
+     */
+    #buildGitCommand() {
+        if (this.changesOption === 'uncommitted') {
+            return this.#GIT_COMMANDS.uncommitted;
+        }
+
+        const committedMatch = this.changesOption.match(/^committed(?:-(\d+))?$/);
+        if (committedMatch) {
+            const commitsBack = committedMatch[1]; // May be undefined or a string representing a number
+
+            if (commitsBack !== undefined) {
+                const commitsBackNum = parseInt(commitsBack, 10);
+
+                if (isNaN(commitsBackNum) || commitsBackNum < 1 || commitsBackNum > 10) {
+                    throw new Error(`❌ Invalid 'committed-N' value: '${this.changesOption}'. N must be between 1 and 10.`);
+                }
+
+                return `git show --name-only --pretty="" HEAD~${commitsBackNum}`;
+            }
+
+            return `git show --name-only --pretty="" HEAD`;
+        }
+
+        throw new Error(`❌ Invalid changes option: '${this.changesOption}'. Expected 'uncommitted', 'committed', or 'committed-N' where N is 1 - 10.`);
+    }
+
+    /**
      * Retrieves a list of changed Git files based on the selected `changesOption`.
      * 
      * - If `changesOption` is `"committed"` -> 'git show --name-only --pretty="" HEAD':
      * it gets files from the latest commit (`HEAD`)
+     * - If `changesOption` is `"committed-1"` -> 'git show --name-only --pretty="" HEAD~1':
+     * it gets files from the needed commit
      * - If `changesOption` is `"uncommitted"` (default) -> 'git diff --name-only' cmd:
      * it gets staged/unstaged changes in the working directory
      * 
      * @returns {this|undefined} The current instance if success, or `undefined` if no changes are found.
      */
     getGitChangedFiles() {
-        const cmd = this.#GIT_COMMANDS[this.changesOption] || this.#GIT_COMMANDS.uncommitted;
+        // const cmd = this.#GIT_COMMANDS[this.changesOption] || this.#GIT_COMMANDS.uncommitted;
+        let cmd;
+        try {
+            cmd = this.#buildGitCommand();
+        } 
+        catch (err) {
+            console.error(APP_PREFIX, err.message);
+            return undefined;
+        }
         
         console.error(APP_PREFIX, `ℹ️  We will use '${cmd}' Git command.`);
 
         if (cmd.includes("diff")) console.log(APP_PREFIX, `['git diff --name-only' command is a default]`);
 
-        this.changedFiles =  this.#getChangedFilesFromGit(cmd);
+        try {
+            this.changedFiles =  this.#getChangedFilesFromGit(cmd);
 
-        if (this.changedFiles.length === 0) {
-            console.log(APP_PREFIX, 'ℹ️  No files changed in the latest Git commit. Skipping coverage processing.');
-            return undefined;
+            if (this.changedFiles.length === 0) {
+                console.log(APP_PREFIX, 'ℹ️  No files changed in the latest Git commit. Skipping coverage processing.');
+                return undefined;
+            }
         }
+        catch (err) {
+            console.error(APP_PREFIX, err.message);
+            console.error(APP_PREFIX, "🔍 Pls, check this Git command manually to understand the original problem.");
+            return undefined;
+        }        
 
         console.log(APP_PREFIX, `📑  GIT changed files:\n  - ${this.changedFiles.join('\n  - ')}`);        
         return this;

--- a/src/coverage.js
+++ b/src/coverage.js
@@ -1,0 +1,186 @@
+import createDebugMessages from 'debug';
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+import yaml from 'js-yaml';
+import { minimatch } from 'minimatch';
+
+import { APP_PREFIX } from './constants.js';
+import TestomatClient from './client.js';
+import { config } from './config.js';
+
+const debug = createDebugMessages('@testomatio/reporter:coverage');
+
+export default class Coverage {
+    constructor(opts = {}) {
+        this.coverageFilePath = opts.filepath || undefined;
+        if (!this.coverageFilePath) throw new Error('Coverage file path must be provided.');
+        // this.coverageBranch = opts.branch || ""; for future
+
+        this.apiKey = opts.apiKey;
+        this.formattedDate = new Date().toISOString().replace(/T/, '-').replace(/:/g, '-').split('.')[0];
+        this.title = opts.title || `Test Coverage Execution - ${this.formattedDate}`;
+        this.client = opts.client || undefined;
+        if (!this.client) throw new Error('Client must be provided.');
+        // this.client = new TestomatClient({ apiKey: this.apiKey, title: this.title, parallel: true });
+
+        this.parsedCoverage = {}
+        this.changedFiles = [];
+        this.tests = new Set();
+        this.suiteIds = new Set();
+        this.tagLabels = new Set();
+    }
+
+    getChangedFiles() {
+        try {
+            const diffOutput = execSync('git diff --name-only', {
+                encoding: 'utf-8',
+                stdio: ['pipe', 'pipe', 'ignore']
+            });
+            this.changedFiles = diffOutput
+                .split('\n')
+                .map(f => f.trim())
+                .filter(Boolean);
+
+            // Git edge case-1: No git diff changed files
+            if (this.changedFiles.length === 0) {
+                console.log(APP_PREFIX, 'ℹ️  No Git changed files detected. Skipping coverage processing.');
+                return;
+            }
+
+            console.log(APP_PREFIX, `📑  GIT changed files:\n  - ${this.changedFiles.join('\n  - ')}`);
+            return this.changedFiles;
+        }
+        catch (err) {
+            const errorMessage = err.message || '';
+            // Git edge case-2: Not a git repository or other error
+            if (errorMessage.includes('Not a git repository')) {
+                console.error(APP_PREFIX, '❌ Error: This folder is not a Git repository.');
+            }
+            else {
+                console.error(APP_PREFIX, '❌ Failed to get Git changed files:', errorMessage);
+            }
+
+            return;
+        }
+    }
+
+    validateCoverageFile() {
+        // Validate the presence of the coverage filepath
+        if (!fs.existsSync(this.coverageFilePath)) {
+            console.log(APP_PREFIX, '❌ Coverage file not found:', this.coverageFilePath);
+            return;
+        }
+
+        // Ensure the given path is a file (not a directory or other type)
+        const stat = fs.statSync(this.coverageFilePath);
+        if (!stat.isFile()) {
+            console.log(APP_PREFIX, '❌ Provided coverage path is not a file:', this.coverageFilePath);
+            return;
+        }
+
+        // Validate the file extension to be ".yml" to ensure it's a YAML file
+        if (path.extname(this.coverageFilePath) !== ".yml") {
+            console.log(APP_PREFIX, '❌ Coverage file must have a .yml extension:', this.coverageFilePath);
+            return;
+        }
+
+        debug(`Coverage file is OK! (path = ${this.coverageFilePath})`);
+
+        return this.coverageFilePath;
+    }
+
+    parseCoverageFile() {
+        try {
+            // Read the contents of the YAML file and attempt to parse the YAML into a JavaScript object
+            const rawYml = fs.readFileSync(this.coverageFilePath, 'utf8');
+            this.parsedCoverage = yaml.load(rawYml) || {};
+
+            console.log(APP_PREFIX, `✅ Coverage file parsed successfully: ${this.coverageFilePath}`);
+
+            return this.parsedCoverage;
+        }
+        catch (err) {
+            console.error(APP_PREFIX, '❌ Failed to parse YAML:', err.message);
+            return;
+        }
+    }
+
+    extractRelevantTestIds() {
+        const matchedLines = new Set();
+
+        for (const changedFile of this.changedFiles) {
+            for (const [pattern, ids] of Object.entries(this.parsedCoverage)) {
+              if (minimatch(changedFile, pattern)) {
+                matchedLines.add(changedFile);
+      
+                ids.forEach(id => {
+                    // Example: "@Tt74099t1"
+                    if (id.startsWith('@T')) {
+                        this.tests.add(id.slice(1));
+                    }
+                    // Example: "@Sd74099c1"
+                    else if (id.startsWith('@S')) {
+                        this.suiteIds.add(id.slice(1));
+                    }
+                    // Example: "tag:@TestSmoke"
+                    else if (id.startsWith('tag')) {
+                        this.tagLabels.add(id.split(':')[1].slice(1));
+                    }
+                });
+              }
+            }
+        }
+
+        if (matchedLines.size === 0) {
+            console.log(APP_PREFIX, 'ℹ️  No matching entries in coverage file for Git changes.');
+            return;
+        }
+
+        debug(`Matched lines: ${matchedLines}`);
+
+        return {
+            tests: this.tests,
+            suiteIds: this.suiteIds,
+            tagLabels: this.tagLabels
+        }
+    }
+
+    getGrepCommand() {
+        if (this.tests.size === 0) {
+          console.log(APP_PREFIX, 'ℹ️  No tests found for execution based on Git changes and coverage.');
+          return;
+        }
+    
+        const grepPattern = [...this.tests].join('|');
+        debug(`Full -grep command: --grep "(${grepPattern})"`);
+
+        return ` --grep "(${grepPattern})"`; //TODO: or ` --grep (${grepPattern})` ???
+    }
+
+    async resolveTestIdsFromAttributes() {
+        await this._resolveAttributeSet(this.tagLabels, 'tag-name');
+        // await this._resolveAttributeSet(this.suiteIds, 'suite'); // for the future
+    }    
+
+    async _resolveAttributeSet(set, type) {
+        try {
+            const promises = [...set].map(async val =>
+                this.client.prepareRun({ pipe: "testomatio", pipeOptions: `${type}=${val}` }) // OR use as in filter: tag-name=smoke
+                    .then(tests => {
+                        if (Array.isArray(tests) && tests.length > 0) {
+                            tests.forEach(testId => this.tests.add(testId));
+                        }
+                        else {
+                            console.log(APP_PREFIX, `🔍 No test by ${type}=${val} were found on the server side`);
+                        }
+                    })
+            );
+
+            await Promise.all(promises);
+        }
+        catch (err) {
+            console.log(APP_PREFIX, `❌ Failed to retrieve the list of TAGGED tests: ${err}`);
+        }
+    }
+}

--- a/src/coverage.js
+++ b/src/coverage.js
@@ -6,8 +6,6 @@ import yaml from 'js-yaml';
 import { minimatch } from 'minimatch';
 
 import { APP_PREFIX } from './constants.js';
-import TestomatClient from './client.js';
-import { config } from './config.js';
 
 const debug = createDebugMessages('@testomatio/reporter:coverage');
 
@@ -15,14 +13,10 @@ export default class Coverage {
     constructor(opts = {}) {
         this.coverageFilePath = opts.filepath || undefined;
         if (!this.coverageFilePath) throw new Error('Coverage file path must be provided.');
-        // this.coverageBranch = opts.branch || ""; for future
+        // this.coverageBranch = opts.branch || ""; TODO: for future
 
-        this.apiKey = opts.apiKey;
-        this.formattedDate = new Date().toISOString().replace(/T/, '-').replace(/:/g, '-').split('.')[0];
-        this.title = opts.title || `Test Coverage Execution - ${this.formattedDate}`;
         this.client = opts.client || undefined;
         if (!this.client) throw new Error('Client must be provided.');
-        // this.client = new TestomatClient({ apiKey: this.apiKey, title: this.title, parallel: true });
 
         this.parsedCoverage = {}
         this.changedFiles = [];
@@ -147,12 +141,15 @@ export default class Coverage {
     }
 
     getGrepCommand() {
-        if (this.tests.size === 0) {
+        //TODO: for Coverage v1 I get list of suiteIds & tests -> maybe I should get list of suite tests from the server in future???
+        const combinedTests = new Set([...this.tests, ...this.suiteIds]);
+
+        if (combinedTests.size === 0) {
           console.log(APP_PREFIX, 'ℹ️  No tests found for execution based on Git changes and coverage.');
           return;
         }
     
-        const grepPattern = [...this.tests].join('|');
+        const grepPattern = [...combinedTests].join('|');
         debug(`Full -grep command: --grep "(${grepPattern})"`);
 
         return ` --grep "(${grepPattern})"`; //TODO: or ` --grep (${grepPattern})` ???
@@ -160,7 +157,7 @@ export default class Coverage {
 
     async resolveTestIdsFromAttributes() {
         await this._resolveAttributeSet(this.tagLabels, 'tag-name');
-        // await this._resolveAttributeSet(this.suiteIds, 'suite'); // for the future
+        // await this._resolveAttributeSet(this.suiteIds, 'suite'); // for the future -> get list of all suite tests
     }    
 
     async _resolveAttributeSet(set, type) {

--- a/src/coverage.js
+++ b/src/coverage.js
@@ -10,9 +10,16 @@ import { APP_PREFIX } from './constants.js';
 const debug = createDebugMessages('@testomatio/reporter:coverage');
 
 export default class Coverage {
+    #GIT_COMMANDS = {
+        committed: 'git show --name-only --pretty="" HEAD', //TODO: by number of commits like HEAD~3 ???
+        uncommitted: 'git diff --name-only'
+    }
+    #GIT_DEFAULT_MARKER = 'uncommitted';
+
     constructor(opts = {}) {
         this.coverageFilePath = opts.filepath || undefined;
         if (!this.coverageFilePath) throw new Error('Coverage file path must be provided.');
+        this.changesOption = opts.changes || this.#GIT_DEFAULT_MARKER; // Default = "uncommitted" if not provided
         // this.coverageBranch = opts.branch || ""; TODO: for future
 
         this.client = opts.client || undefined;
@@ -25,65 +32,112 @@ export default class Coverage {
         this.tagLabels = new Set();
     }
 
-    getChangedFiles() {
+    /**
+     * Executes a Git command to retrieve a list of changed files.
+     *
+     * @param {string} cmd - The Git command to execute.
+     * @returns {string[]} An array of changed file paths. Returns an empty array if an error occurs
+     * (e.g., not a Git repository or command failure).
+     */
+    #getChangedFilesFromGit(cmd) {
         try {
-            const diffOutput = execSync('git diff --name-only', {
+            const result = execSync(cmd, {
                 encoding: 'utf-8',
                 stdio: ['pipe', 'pipe', 'ignore']
             });
-            this.changedFiles = diffOutput
+    
+            return result
                 .split('\n')
                 .map(f => f.trim())
                 .filter(Boolean);
-
-            // Git edge case-1: No git diff changed files
-            if (this.changedFiles.length === 0) {
-                console.log(APP_PREFIX, 'ℹ️  No Git changed files detected. Skipping coverage processing.');
-                return;
-            }
-
-            console.log(APP_PREFIX, `📑  GIT changed files:\n  - ${this.changedFiles.join('\n  - ')}`);
-            return this.changedFiles;
-        }
+        } 
         catch (err) {
             const errorMessage = err.message || '';
-            // Git edge case-2: Not a git repository or other error
+            // Git edge: Not a git repository or other error
             if (errorMessage.includes('Not a git repository')) {
                 console.error(APP_PREFIX, '❌ Error: This folder is not a Git repository.');
+            } else {
+                console.error(APP_PREFIX, `❌ Git command failed ("${cmd}"):\n`, errorMessage);
             }
-            else {
-                console.error(APP_PREFIX, '❌ Failed to get Git changed files:', errorMessage);
-            }
-
-            return;
+    
+            return [];
         }
     }
 
+    /**
+     * Retrieves a list of changed Git files based on the selected `changesOption`.
+     * 
+     * - If `changesOption` is `"committed"` -> 'git show --name-only --pretty="" HEAD': it gets files from the latest commit (`HEAD`).
+     * - If `changesOption` is `"uncommitted"` (default) -> 'git diff --name-only' cmd: it gets staged/unstaged changes in the working directory.
+     * Logs a message if no changes are detected.
+     * 
+     * @returns {this|undefined} The current instance if success, or `undefined` if no changes are found.
+     */
+    getGitChangedFiles() {
+        const cmd = this.#GIT_COMMANDS[this.changesOption] || this.#GIT_COMMANDS.uncommitted; //TODO: move to constructor???
+        
+        console.error(APP_PREFIX, `ℹ️  We will use '${cmd}' Git command.`);
+
+        if (cmd.includes("diff")) console.log(APP_PREFIX, `['git diff --name-only' command is a default]`);
+
+        this.changedFiles =  this.#getChangedFilesFromGit(cmd);
+
+        if (this.changedFiles.length === 0) {
+            console.log(APP_PREFIX, 'ℹ️  No files changed in the latest Git commit. Skipping coverage processing.');
+            return undefined;
+        }
+
+        console.log(APP_PREFIX, `📑  GIT changed files:\n  - ${this.changedFiles.join('\n  - ')}`);        
+        return this;
+    }
+
+    /**
+     * Validates the coverage file path (stored in `this.coverageFilePath`).
+     *
+     * This method checks:
+     * - That the file exists on disk.
+     * - That it is a regular file (not a directory or special file).
+     * - That it has a `.yml` extension to ensure it's a YAML file.
+     *
+     * Logs descriptive error messages for any failures.
+     *
+     * @returns {this|undefined} The current instance if all checks pass; otherwise, `undefined`.
+     */
     validateCoverageFile() {
         // Validate the presence of the coverage filepath
         if (!fs.existsSync(this.coverageFilePath)) {
             console.log(APP_PREFIX, '❌ Coverage file not found:', this.coverageFilePath);
-            return;
+            return undefined;
         }
 
         // Ensure the given path is a file (not a directory or other type)
         const stat = fs.statSync(this.coverageFilePath);
         if (!stat.isFile()) {
             console.log(APP_PREFIX, '❌ Provided coverage path is not a file:', this.coverageFilePath);
-            return;
+            return undefined;
         }
 
         // Validate the file extension to be ".yml" to ensure it's a YAML file
         if (path.extname(this.coverageFilePath) !== ".yml") {
             console.log(APP_PREFIX, '❌ Coverage file must have a .yml extension:', this.coverageFilePath);
-            return;
+            return undefined;
         }
 
         debug(`Coverage file is OK! (path = ${this.coverageFilePath})`);
 
-        return this.coverageFilePath;
+        return this;
     }
 
+    /**
+     * Parses the YAML coverage file (located at `this.coverageFilePath`) into a JavaScript object.
+     *
+     * - Reads the file content using UTF-8 encoding.
+     * - Parses it as YAML using the `yaml` library.
+     * - Stores the result in `this.parsedCoverage`.
+     * - If parsing fails, logs an error and returns `undefined`.
+     *
+     * @returns {this|undefined} The current instance if success, or `undefined` if parsing fails.
+     */
     parseCoverageFile() {
         try {
             // Read the contents of the YAML file and attempt to parse the YAML into a JavaScript object
@@ -92,17 +146,17 @@ export default class Coverage {
 
             console.log(APP_PREFIX, `✅ Coverage file parsed successfully: ${this.coverageFilePath}`);
 
-            return this.parsedCoverage;
+            return this;
         }
         catch (err) {
             console.error(APP_PREFIX, '❌ Failed to parse YAML:', err.message);
-            return;
+            return undefined;
         }
     }
 
-    extractRelevantTestIds() {
+    async extractRelevantTestsFromChanges() { 
         const matchedLines = new Set();
-
+        
         for (const changedFile of this.changedFiles) {
             for (const [pattern, ids] of Object.entries(this.parsedCoverage)) {
               if (minimatch(changedFile, pattern)) {
@@ -115,7 +169,7 @@ export default class Coverage {
                     }
                     // Example: "@Sd74099c1"
                     else if (id.startsWith('@S')) {
-                        this.suiteIds.add(id.slice(1));
+                        this.tests.add(id.slice(1));
                     }
                     // Example: "tag:@TestSmoke"
                     else if (id.startsWith('tag')) {
@@ -127,57 +181,57 @@ export default class Coverage {
         }
 
         if (matchedLines.size === 0) {
-            console.log(APP_PREFIX, 'ℹ️  No matching entries in coverage file for Git changes.');
+            console.log(APP_PREFIX, 'ℹ️  No matching entries in coverage file for provided Git changes.');
             return;
         }
 
         debug(`Matched lines: ${matchedLines}`);
 
-        return {
-            tests: this.tests,
-            suiteIds: this.suiteIds,
-            tagLabels: this.tagLabels
-        }
-    }
-
-    getGrepCommand() {
-        //TODO: for Coverage v1 I get list of suiteIds & tests -> maybe I should get list of suite tests from the server in future???
-        const combinedTests = new Set([...this.tests, ...this.suiteIds]);
-
-        if (combinedTests.size === 0) {
-          console.log(APP_PREFIX, 'ℹ️  No tests found for execution based on Git changes and coverage.');
-          return;
-        }
-    
-        const grepPattern = [...combinedTests].join('|');
-        debug(`Full -grep command: --grep "(${grepPattern})"`);
-
-        return ` --grep "(${grepPattern})"`; //TODO: or ` --grep (${grepPattern})` ???
-    }
-
-    async resolveTestIdsFromAttributes() {
-        await this._resolveAttributeSet(this.tagLabels, 'tag-name');
-        // await this._resolveAttributeSet(this.suiteIds, 'suite'); // for the future -> get list of all suite tests
-    }    
-
-    async _resolveAttributeSet(set, type) {
+        // Get test IDs by provided additional test attributes from the server side        
         try {
-            const promises = [...set].map(async val =>
-                this.client.prepareRun({ pipe: "testomatio", pipeOptions: `${type}=${val}` }) // OR use as in filter: tag-name=smoke
-                    .then(tests => {
-                        if (Array.isArray(tests) && tests.length > 0) {
-                            tests.forEach(testId => this.tests.add(testId));
-                        }
-                        else {
-                            console.log(APP_PREFIX, `🔍 No test by ${type}=${val} were found on the server side`);
-                        }
-                    })
-            );
-
-            await Promise.all(promises);
+            await this.#resolveTestomatioAttributeTests(this.tagLabels, 'tag-name');
+            // await this._resolveAttributeSet(this.suiteIds, 'suite'); // for the future -> get list of all suite tests
         }
         catch (err) {
-            console.log(APP_PREFIX, `❌ Failed to retrieve the list of TAGGED tests: ${err}`);
+            console.log(APP_PREFIX, `❌ Failed to retrieve the list of Attribute tests: ${err}`);
         }
+
+        if (this.tests.size === 0) {
+            console.log(APP_PREFIX, 'ℹ️  No tests found for execution based on Git changes and coverage.');
+            return;
+        }
+
+        return this.tests;
+    }
+
+    /**
+     * Generates a `--grep` command-line argument for test filtering based on collected test IDs.
+     *
+     * - Converts the `this.tests` Set into a pipe-separated string pattern (e.g., `id1|id2|id3`).
+     * - Formats it as a Mocha, Codecept, Playwright-compatible `--grep` flag.
+     *
+     * @returns {string} A formatted grep command string (e.g., ` --grep "(id1|id2|id3)"`). Returns an empty pattern if `this.tests` is empty.
+     */
+    getGrepCommand() {
+        const grepPattern = [...this.tests].join('|');
+        debug(`Full -grep command: --grep "(${grepPattern})"`);
+
+        return ` --grep "(${grepPattern})"`;
+    }   
+
+    async #resolveTestomatioAttributeTests(set, type) {
+        const promises = [...set].map(async val =>
+            this.client.prepareRun({ pipe: "testomatio", pipeOptions: `${type}=${val}` }) // OR use as in filter: tag-name=smoke
+                .then(tests => {
+                    if (Array.isArray(tests) && tests.length > 0) {
+                        tests.forEach(testId => this.tests.add(testId));
+                    }
+                    else {
+                        console.log(APP_PREFIX, `🔍 No test by ${type}=${val} were found on the server side`);
+                    }
+                })
+        );
+
+        await Promise.all(promises);
     }
 }

--- a/src/coverage.js
+++ b/src/coverage.js
@@ -101,7 +101,9 @@ export default class Coverage {
                 const commitsBackNum = parseInt(commitsBack, 10);
 
                 if (isNaN(commitsBackNum) || commitsBackNum < 1 || commitsBackNum > 10) {
-                    throw new Error(`❌ Invalid 'committed-N' value: '${this.changesOption}'. N must be between 1 and 10.`);
+                    throw new Error(
+                        `❌ Invalid 'committed-N' value: '${this.changesOption}'. ` +
+                        `N must be between 1 and 10.`);
                 }
 
                 return `git show --name-only --pretty="" HEAD~${commitsBackNum}`;
@@ -110,7 +112,9 @@ export default class Coverage {
             return `git show --name-only --pretty="" HEAD`;
         }
 
-        throw new Error(`❌ Invalid changes option: '${this.changesOption}'. Expected 'uncommitted', 'committed', or 'committed-N' where N is 1 - 10.`);
+        throw new Error(
+            `❌ Invalid changes option: '${this.changesOption}'. ` + 
+            `Expected 'uncommitted', 'committed', or 'committed-N' where N is 1 - 10.`);
     }
 
     /**

--- a/src/coverage.js
+++ b/src/coverage.js
@@ -13,7 +13,7 @@ export default class Coverage {
     #GIT_COMMANDS = {
         committed: 'git show --name-only --pretty="" HEAD', //TODO: by number of commits like HEAD~3 ???
         uncommitted: 'git diff --name-only'
-    }
+    };
     #GIT_DEFAULT_MARKER = 'uncommitted';
 
     constructor(opts = {}) {
@@ -25,7 +25,7 @@ export default class Coverage {
         this.client = opts.client || undefined;
         if (!this.client) throw new Error('Client must be provided.');
 
-        this.parsedCoverage = {}
+        this.parsedCoverage = {};
         this.changedFiles = [];
         this.tests = new Set();
         this.suiteIds = new Set();
@@ -67,14 +67,15 @@ export default class Coverage {
     /**
      * Retrieves a list of changed Git files based on the selected `changesOption`.
      * 
-     * - If `changesOption` is `"committed"` -> 'git show --name-only --pretty="" HEAD': it gets files from the latest commit (`HEAD`).
-     * - If `changesOption` is `"uncommitted"` (default) -> 'git diff --name-only' cmd: it gets staged/unstaged changes in the working directory.
-     * Logs a message if no changes are detected.
+     * - If `changesOption` is `"committed"` -> 'git show --name-only --pretty="" HEAD':
+     * it gets files from the latest commit (`HEAD`)
+     * - If `changesOption` is `"uncommitted"` (default) -> 'git diff --name-only' cmd:
+     * it gets staged/unstaged changes in the working directory
      * 
      * @returns {this|undefined} The current instance if success, or `undefined` if no changes are found.
      */
     getGitChangedFiles() {
-        const cmd = this.#GIT_COMMANDS[this.changesOption] || this.#GIT_COMMANDS.uncommitted; //TODO: move to constructor???
+        const cmd = this.#GIT_COMMANDS[this.changesOption] || this.#GIT_COMMANDS.uncommitted;
         
         console.error(APP_PREFIX, `ℹ️  We will use '${cmd}' Git command.`);
 
@@ -210,7 +211,8 @@ export default class Coverage {
      * - Converts the `this.tests` Set into a pipe-separated string pattern (e.g., `id1|id2|id3`).
      * - Formats it as a Mocha, Codecept, Playwright-compatible `--grep` flag.
      *
-     * @returns {string} A formatted grep command string (e.g., ` --grep "(id1|id2|id3)"`). Returns an empty pattern if `this.tests` is empty.
+     * @returns {string} A formatted grep command string (e.g., ` --grep "(id1|id2|id3)"`). 
+     * Returns an empty pattern if `this.tests` is empty.
      */
     getGrepCommand() {
         const grepPattern = [...this.tests].join('|');
@@ -221,7 +223,7 @@ export default class Coverage {
 
     async #resolveTestomatioAttributeTests(set, type) {
         const promises = [...set].map(async val =>
-            this.client.prepareRun({ pipe: "testomatio", pipeOptions: `${type}=${val}` }) // OR use as in filter: tag-name=smoke
+            this.client.prepareRun({ pipe: "testomatio", pipeOptions: `${type}=${val}` })
                 .then(tests => {
                     if (Array.isArray(tests) && tests.length > 0) {
                         tests.forEach(testId => this.tests.add(testId));


### PR DESCRIPTION
Coverage task v1 updates: 
- a new Coverage class
- review Coverage class + combine filter & coverage to one run section
- compare current branch with master??? - **WIP**
- example of coverage.yml file??? - **WIP**
- create a new test plan at the end??? - **WIP**

Short Coverage task description:
- Retrieved modified files using `git diff --name-only` cmd;
- Validated coverage file  & parsed relevant coverage data;
- Extracted test IDs and generated a full `--grep` command for targeted test runs;
(original ticket - https://github.com/testomatio/playtika-issues/issues/32 )

Example:
- command: `TESTOMATIO_URL=http://xxx TESTOMATIO=tstxxx npx start-test-run -c 'npx codeceptjs run' --coverage 'filepath:coverage/coverage.yml'`
- `coverage.yml` file example: 
```yml
// coverage.yml
todomvc-tests/helpers/**:
  - "@S171a8408"
  - "@T091ed49e"
todomvc-tests/edit-todos_test.js:
  - "@T091ed49e"
todomvc-tests/pages/**/*.js:
  - "tag:@step-06"
  - "@Safaa0ab4"

```
<img width="1872" height="619" alt="Screenshot-coverage-example-1-2-blure" src="https://github.com/user-attachments/assets/61d0c831-0882-4b40-9db2-49761b38ec0b" />

