### PR TITLE
[COVERAGE RUN PIPE] Expand start-test(run) command by coverage-mode

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -96,10 +96,12 @@ Alias for this command – `test`, e.g. `npx @testomatio/reporter test [options]
 
 ```bash
 npx @testomatio/reporter run "npm test"
+npx @testomatio/reporter run "npx jest" --filter-list "testomatio:tag-name=frontend"
 npx @testomatio/reporter run "npx jest" --filter "testomatio:tag-name=frontend"
 npx @testomatio/reporter run "npx jest" --filter "testomatio:label=Smoke"
 npx @testomatio/reporter run "npx jest" --filter "testomatio:jira=TC-123"
 npx @testomatio/reporter run "npx jest" --filter "testomatio:plan=a123fb12"
+npx @testomatio/reporter run "npx jest" --filter-list "coverage:file=coverage.yml,diff=user-branch"
 npx @testomatio/reporter run "npx jest" --filter "coverage:file=coverage.yml,diff=user-branch"
 npx @testomatio/reporter run "npx jest" --filter "coverage:file=coverage/coverage.yml"
 npx @testomatio/reporter run "mocha tests/" --env-file .env.test
@@ -124,8 +126,10 @@ Output:
 ```bash
 [TESTOMATIO] 🚫 Unsupported --filter mode: "tcoverage".
 ✅ Supported formats:
-   • "coverage:<options>" (e.g., --filter="coverage:file=coverage.yml")
-   • "testomatio:<options>" (e.g., --filter="testomatio:tag-name=smoke")
+   • "coverage:<options>" (e.g., --filter-list "coverage:file=coverage.yml")
+   • "coverage:<options>" (e.g., --filter "coverage:file=coverage.yml")
+   • "testomatio:<options>" (e.g., --filter-list "testomatio:tag-name=smoke")
+   • "testomatio:<options>" (e.g., --filter "testomatio:tag-name=smoke")
 
 👉 Please refer to the documentation for supported options and usage examples.
 ```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -96,7 +96,7 @@ Alias for this command – `test`, e.g. `npx @testomatio/reporter test [options]
 
 ```bash
 npx @testomatio/reporter run "npm test"
-npx @testomatio/reporter run "npx jest" --filter "testomatio:tag=frontend"
+npx @testomatio/reporter run "npx jest" --filter "testomatio:tag-name=frontend"
 npx @testomatio/reporter run "npx jest" --filter "testomatio:label=Smoke"
 npx @testomatio/reporter run "npx jest" --filter "testomatio:jira=TC-123"
 npx @testomatio/reporter run "npx jest" --filter "testomatio:plan=a123fb12"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -107,6 +107,29 @@ npx @testomatio/reporter run "npm test" --kind manual
 npx @testomatio/reporter run "npx jest" --kind mixed
 ```
 
+#### 3.1 run by "--filter" option
+
+⚠️ Note on unsupported --filter modes
+
+If you provide a --filter value that does not start with either `testomatio:` or `coverage:` ,
+the reporter will stop execution and print a clear error message.
+
+Example of wrong command:
+```bash
+npx @testomatio/reporter run "npx jest" --filter "tcoverage:file=coverage.yml"
+```
+
+Output:
+
+```bash
+[TESTOMATIO] 🚫 Unsupported --filter mode: "tcoverage".
+✅ Supported formats:
+   • "coverage:<options>" (e.g., --filter="coverage:file=coverage.yml")
+   • "testomatio:<options>" (e.g., --filter="testomatio:tag-name=smoke")
+
+👉 Please refer to the documentation for supported options and usage examples.
+```
+
 > Previously known as: `npx start-test-run -c "command"` _(before 1.6.0)_
 
 ### 4. xml

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -100,6 +100,8 @@ npx @testomatio/reporter run "npx jest" --filter "testomatio:tag-name=frontend"
 npx @testomatio/reporter run "npx jest" --filter "testomatio:label=Smoke"
 npx @testomatio/reporter run "npx jest" --filter "testomatio:jira=TC-123"
 npx @testomatio/reporter run "npx jest" --filter "testomatio:plan=a123fb12"
+npx @testomatio/reporter run "npx jest" --filter "coverage:file=coverage.yml,diff=user-branch"
+npx @testomatio/reporter run "npx jest" --filter "coverage:file=coverage/coverage.yml"
 npx @testomatio/reporter run "mocha tests/" --env-file .env.test
 npx @testomatio/reporter run "npm test" --kind manual
 npx @testomatio/reporter run "npx jest" --kind mixed

--- a/docs/pipes.md
+++ b/docs/pipes.md
@@ -33,6 +33,7 @@ Pipes Concepts:
 - [CSV](./pipes/csv.md)
 - [Bitbucket](./pipes/bitbucket.md)
 - [Debug](./pipes/debug.md)
+- [Coverage](./pipes/coverage.md)
 
 ## Custom Pipe
 

--- a/docs/pipes/coverage.md
+++ b/docs/pipes/coverage.md
@@ -29,17 +29,15 @@ The coverage file defines mappings between changed source files and the tests or
 ✅ Sample coverage.yml
 
 ```yaml
-todomvc-tests/helpers/**:
+src/Auth/*.tsx:
   - "@S171a8"
-  - "@T091e"
-  - "tag:@smoke"
+  - "tag:@auth"
 
-todomvc-tests/edit-todos_test.js:
+src/Admin/**:
   - "@T0922"
 
-todomvc-tests/pages/**/*.js:
-  - "tag:@step-06"
-  - "@Safa7"
+src/Checkout/**/*.tsx:
+  - "tag:@checkaut"
 ```
 
 _(For now we cover only cases where suiteid/testid/tag can be used as coverage values)_

--- a/docs/pipes/coverage.md
+++ b/docs/pipes/coverage.md
@@ -1,0 +1,120 @@
+## Coverage Pipe
+
+![](./images/coverage.png)
+
+The **Coverage Pipe** allows you to dynamically filter tests based on actual code changes and a coverage report. It uses Git diff and a coverage file to detect which tests are impacted by modified files, so you only run what's necessary.
+
+This is useful for:
+- Running only tests related to recent changes (faster CI)
+- Saving compute time in large test suites
+- Testing hotfixes or feature branches with precision
+
+## Coverage Pipe Functionality preset
+
+1. A valid **coverage file** (see example below).
+2. A **Git diff target** branch to compare against (optional, defaults to `master`).
+
+Simple command usage:
+
+```bash
+--filter "coverage:file=<path_to_coverage.yml>[,diff=<git_branch>]"
+```
+_(more commands you can find below in this file)_
+
+
+## 📄 Example Coverage File Format (we use "coverage.yml" as default one)
+
+The coverage file defines mappings between changed source files and the tests or tags associated with them. This allows the Coverage Pipe to determine which tests to run based on file changes in Git.
+
+✅ Sample coverage.yml
+
+```yaml
+todomvc-tests/helpers/**:
+  - "@S171a8"
+  - "@T091e"
+  - "tag:@smoke"
+
+todomvc-tests/edit-todos_test.js:
+  - "@T0922"
+
+todomvc-tests/pages/**/*.js:
+  - "tag:@step-06"
+  - "@Safa7"
+```
+
+### 🧠 How It Works
+
+* Each key is a glob pattern or file path that matches changed files.
+* Each value is a list of:
+-- Test IDs (e.g., @T091e)
+-- Suite IDs (e.g., @S171a8)
+-- Tag references (e.g., tag:@smoke)
+
+**When a file matches a key, the corresponding tests are included in the run**
+
+### 💡 Tips
+
+* Use **/*.js patterns to cover folders or extensions.
+* You can mix test IDs and tags freely.
+* Multiple patterns can map to the same test or tag.
+
+---
+
+## 📘 Usage Examples
+
+* Run tests related to changed files using coverage data by the default `master` Git branch
+```bash
+npx @testomatio/reporter run "npx jest" --filter "coverage:file=coverage.yml"
+```
+
+* Compare changes to a specific Git branch
+```bash
+npx @testomatio/reporter run "npx jest" --filter "coverage:file=coverage/coverage.yml,diff=develop"
+```
+
+### ⚠️ Error Scenarios
+
+* Missing or misspelled coverage file
+```bash
+npx @testomatio/reporter run "npx jest" --filter "coverage:file=no-exist.yml"
+#  Error case =>>> ❌ Coverage file not found: no-exist.yml
+```
+
+* Invalid Git branch
+```bash
+npx @testomatio/reporter run "npx jest" --filter "coverage:file=coverage.yml,diff=no-such-branch"
+#  Error case =>>> ❌ Git command failed: git diff no-such-branch --name-only
+```
+
+* Missing "file" param
+```bash
+npx @testomatio/reporter run "npx jest" --filter "coverage:diff=main"
+#  Error case =>>> 🚫 Missing required parameter: "file"
+```
+
+### 🧪 Git & Coverage Integration Details
+
+| **Option**                                           | **Git Command Used**                  | **Notes**            |
+| ---------------------------------------------------- | ------------------------------------- | -------------------- |
+| `--filter "coverage:file=coverage.yml,diff=feature"` | ✅ `git diff feature --name-only`      | Compare to `feature` |
+| `--filter "coverage:file=coverage.yml"`              | ✅ `git diff master --name-only`       | Defaults to `master` |
+| `--filter "coverage:diff=master,file=coverage.yml"`  | ✅ `git diff master --name-only`       | Order doesn't matter |
+| `--filter "coverage:file=coverage.yml,diff=noexist"` | ❌ Git diff fails                      | Invalid branch       |
+| `--filter "coverage:file=no-exist.yml"`              | ❌ Coverage file not found             | File doesn't exist   |
+| `--filter "coverage:filepath=coverage.yml"`          | 🚫 Missing required parameter: "file" | Invalid key          |
+
+### 🧠 How It Works
+
+**Under the hood, the Coverage Pipe:**
+
+1) Parses Git diff output to find changed files.
+2) Loads the coverage report to map files to test identifiers.
+3) Matches changed files to impacted tests.
+4) Returns a test ID list to be executed.
+5) If the pipe cannot match any tests:
+* You’ll see: `ℹ️ No matching entries in coverage file for provided Git changes.`
+* If no tests are found: `ℹ️ No tests found for execution based on Git changes.`
+
+---
+
+ℹ️ Looking for more dynamic and fast test execution in CI? The Coverage Pipe is your best starting point 👍.

--- a/docs/pipes/coverage.md
+++ b/docs/pipes/coverage.md
@@ -42,6 +42,8 @@ todomvc-tests/pages/**/*.js:
   - "@Safa7"
 ```
 
+_(For now we cover only cases where suiteid/testid/tag can be used as coverage values)_
+
 ### 🧠 How It Works
 
 * Each key is a glob pattern or file path that matches changed files.

--- a/docs/pipes/coverage.md
+++ b/docs/pipes/coverage.md
@@ -62,12 +62,39 @@ _(For now we cover only cases where suiteid/testid/tag can be used as coverage v
 
 ## 📘 Usage Examples
 
-* Run tests related to changed files using coverage data by the default `master` Git branch
+### Retrieve a list of tests matching your filter (without running them):
+_If you want to check which tests match your filter without executing the test runner, use the `--filter-list` option_
+
+This is useful for:
+- debugging your filter expression
+- confirming which tests the server will return
+- CI pipelines that only need to inspect affected tests
+
+**Examples:**
+
+```bash
+npx @testomatio/reporter run --filter-list "coverage:file=coverage.yml"
+```
+
+with a branch comparison:
+
+```bash
+npx @testomatio/reporter run --filter-list "coverage:file=coverage/coverage.yml,diff=develop"
+
+```
+
+### Run tests based on changed files _(by the default `master` Git branch)_:
+
+**Example:**
+
 ```bash
 npx @testomatio/reporter run "npx jest" --filter "coverage:file=coverage.yml"
 ```
 
 * Compare changes to a specific Git branch
+
+**Example:**
+
 ```bash
 npx @testomatio/reporter run "npx jest" --filter "coverage:file=coverage/coverage.yml,diff=develop"
 ```

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -81,6 +81,7 @@ program
   .description('Run tests with the specified command')
   .argument('<command>', 'Test runner command')
   .option('--filter <filter>', 'Additional execution filter')
+  .option('--filter-list <filter>', 'Get a list of all tests by filter before running')
   .option('--kind <type>', 'Specify run type: automated, manual, or mixed')
   .action(async (command, opts) => {
     const apiKey = process.env['INPUT_TESTOMATIO-KEY'] || config.TESTOMATIO;
@@ -93,10 +94,11 @@ program
 
     const client = new TestomatClient({ apiKey, title });
 
-    if (opts.filter) {
+    if (opts.filter || opts.filterList) {
       // Example of use: npx @testomatio/reporter run "npx jest" --filter "testomatio:tag-name=frontend"
       // Example of use: npx @testomatio/reporter run "npx jest" --filter "coverage:file=coverage.yml"
-      const [pipe, ...optsArray] = opts.filter.split(':');
+      // Example of use: npx @testomatio/reporter run "npx jest" --filter-list "coverage:file=coverage.yml"
+      const [pipe, ...optsArray] = opts?.filter ? opts?.filter.split(':') : opts?.filterList.split(':');
       const pipeOptions = optsArray.join(':');
 
       const SUPPORTED_PIPES = ['coverage', 'testomatio'];
@@ -105,17 +107,29 @@ program
         console.log(APP_PREFIX,
           `🚫 Unsupported --filter mode: "${pipe}".\n` +
           '✅ Supported formats:\n' +
-          '   • "coverage:<options>" (e.g., --filter="coverage:file=coverage.yml")\n' +
-          '   • "testomatio:<options>" (e.g., --filter="testomatio:tag-name=smoke")\n\n' +
+          '   • "coverage:<options>" (e.g., --filter-list "coverage:file=coverage.yml")\n' +
+          '   • "coverage:<options>" (e.g., --filter "coverage:file=coverage.yml")\n' +
+          '   • "testomatio:<options>" (e.g., --filter-list "testomatio:tag-name=smoke")\n' +
+          '   • "testomatio:<options>" (e.g., --filter "testomatio:tag-name=smoke")\n\n' +
           '👉 Please refer to the documentation for supported options and usage examples.\n'
         );
         return;
       }
 
-      try {
-        const tests = await client.prepareRun({ pipe, pipeOptions });
+      const prepareRunParams = { pipe, pipeOptions };
 
-        if (!tests || tests.length === 0) return;
+      try {
+        const tests = await client.prepareRun(prepareRunParams);
+
+        if (!tests || tests.length === 0) {
+          console.log(APP_PREFIX, pc.yellow('No tests found.'));
+          return;
+        }
+
+        if(opts.filterList) {
+          console.log(APP_PREFIX, pc.green(`Matched test/suite IDs:: ${tests}`));
+          return;
+        }
 
         const grepPattern = tests.join('|');
         debug(`Full "grep" command: --grep "(${grepPattern})"`);

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -93,79 +93,30 @@ program
 
     const client = new TestomatClient({ apiKey, title });
 
+    // Example of use: npx @testomatio/reporter run "npx jest" --filter "testomatio:tag-name=frontend"
+    // Example of use: npx @testomatio/reporter run "npx jest" --filter="coverage:file=coverage.yml"
     if (opts.filter) {
       const [pipe, ...optsArray] = opts.filter.split(':');
       const pipeOptions = optsArray.join(':');
 
-      if (pipe === 'coverage') { //TODO: change by switch/case format instead of if...else if???
-        // Example of use: npx @testomatio/reporter run "npx jest" --filter "coverage:file=coverage/coverage.yml,diff=master"
-        const options = pipeOptions.split(',');
-        const coverageParams = {};
+      try {
+        const tests = await client.prepareRun({ pipe, pipeOptions });
 
-        for (const option of options) {
-          const [key, value] = option.split('=');
-          if (key && value) {
-            coverageParams[key.trim()] = value.trim();
-          }
-        }
+        if (!tests || tests.length === 0) return;
 
-        try {
-          if (!coverageParams?.file) {
-            console.log(APP_PREFIX,
-              '🚫 Missing required parameter: "file".\n' +
-              '👉 When using Coverage task: you must provide a file path like: "coverage:file=coverage.yml"'
-            );
-            return;
-          }
-
-          process.env.COVERAGE_FILEPATH = coverageParams.file;
-
-          if (coverageParams?.diff) {
-            process.env.COVERAGE_BRANCH = coverageParams.diff; // in case if no "diff" set - "master " branch used as default
-          }
-
-          const tests = await client.prepareRun({ pipe, pipeOptions });
-          
-          if (!tests) return;
-          
-          const grepPattern = [...tests].join('|');
-          debug(`Full "grep" command: --grep "(${grepPattern})"`);
-
-          command += ` --grep "(${grepPattern})"`;
-        }
-        catch (err) {
-          console.log(APP_PREFIX, err);
-          return;
-        }
-      }
-      else if (pipe === 'testomatio') {
-        // Example of use: npx @testomatio/reporter run "npx jest" --filter "testomatio:tag-name=frontend"
-        try {
-          const tests = await client.prepareRun({ pipe, pipeOptions });
-          if (tests && tests.length > 0) {
-            command += ` --grep (${tests.join('|')})`;
-          }
-        } 
-        catch (err) {
-          console.log(APP_PREFIX, err);
-          return;
-        }
-      }
-      else {
-        console.log(APP_PREFIX,
-          `🚫 Unsupported --filter mode: "${pipe}".\n` +
-          '✅ Supported formats:\n' +
-          '   • "coverage:<options>" (e.g., --filter="coverage:file=coverage.yml")\n' +
-          '   • "testomatio:<options>" (e.g., --filter="testomatio:tag-name=smoke")\n\n' +
-          '👉 Please refer to the documentation for supported options and usage examples.\n'
-        );
+        const grepPattern = tests.join('|');
+        debug(`Full "grep" command: --grep "(${grepPattern})"`);
+        
+        command += ` --grep "(${grepPattern})"`;
+      } 
+      catch (err) {
+        console.log(APP_PREFIX, err.message || err);
         return;
       }
     }
 
     console.log(APP_PREFIX, `🚀 Running`, pc.green(command));
-
-    debug("Full command text:", command.split(' '));
+    // console.log("Full command text:", command.split(' ')); //TODO: only for debug!!!! need to remove after testing!!
 
     const runTests = async () => {
       const testCmds = command.split(' ');

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -101,21 +101,6 @@ program
       const [pipe, ...optsArray] = opts?.filter ? opts?.filter.split(':') : opts?.filterList.split(':');
       const pipeOptions = optsArray.join(':');
 
-      const SUPPORTED_PIPES = ['coverage', 'testomatio'];
-
-      if (!SUPPORTED_PIPES.includes(pipe)) {
-        console.log(APP_PREFIX,
-          `🚫 Unsupported --filter mode: "${pipe}".\n` +
-          '✅ Supported formats:\n' +
-          '   • "coverage:<options>" (e.g., --filter-list "coverage:file=coverage.yml")\n' +
-          '   • "coverage:<options>" (e.g., --filter "coverage:file=coverage.yml")\n' +
-          '   • "testomatio:<options>" (e.g., --filter-list "testomatio:tag-name=smoke")\n' +
-          '   • "testomatio:<options>" (e.g., --filter "testomatio:tag-name=smoke")\n\n' +
-          '👉 Please refer to the documentation for supported options and usage examples.\n'
-        );
-        return;
-      }
-
       const prepareRunParams = { pipe, pipeOptions };
 
       try {
@@ -127,7 +112,7 @@ program
         }
 
         if(opts.filterList) {
-          console.log(APP_PREFIX, pc.green(`Matched test/suite IDs:: ${tests}`));
+          console.log(APP_PREFIX, pc.green(`Matched test/suite IDs: ${tests}`));
           return;
         }
 

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -93,11 +93,24 @@ program
 
     const client = new TestomatClient({ apiKey, title });
 
-    // Example of use: npx @testomatio/reporter run "npx jest" --filter "testomatio:tag-name=frontend"
-    // Example of use: npx @testomatio/reporter run "npx jest" --filter="coverage:file=coverage.yml"
     if (opts.filter) {
+      // Example of use: npx @testomatio/reporter run "npx jest" --filter "testomatio:tag-name=frontend"
+      // Example of use: npx @testomatio/reporter run "npx jest" --filter "coverage:file=coverage.yml"
       const [pipe, ...optsArray] = opts.filter.split(':');
       const pipeOptions = optsArray.join(':');
+
+      const SUPPORTED_PIPES = ['coverage', 'testomatio'];
+
+      if (!SUPPORTED_PIPES.includes(pipe)) {
+        console.log(APP_PREFIX,
+          `🚫 Unsupported --filter mode: "${pipe}".\n` +
+          '✅ Supported formats:\n' +
+          '   • "coverage:<options>" (e.g., --filter="coverage:file=coverage.yml")\n' +
+          '   • "testomatio:<options>" (e.g., --filter="testomatio:tag-name=smoke")\n\n' +
+          '👉 Please refer to the documentation for supported options and usage examples.\n'
+        );
+        return;
+      }
 
       try {
         const tests = await client.prepareRun({ pipe, pipeOptions });
@@ -116,7 +129,6 @@ program
     }
 
     console.log(APP_PREFIX, `🚀 Running`, pc.green(command));
-    // console.log("Full command text:", command.split(' ')); //TODO: only for debug!!!! need to remove after testing!!
 
     const runTests = async () => {
       const testCmds = command.split(' ');

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -97,17 +97,75 @@ program
       const [pipe, ...optsArray] = opts.filter.split(':');
       const pipeOptions = optsArray.join(':');
 
-      try {
-        const tests = await client.prepareRun({ pipe, pipeOptions });
-        if (tests && tests.length > 0) {
-          command += ` --grep (${tests.join('|')})`;
+      if (pipe === 'coverage') { //TODO: change by switch/case format instead of if...else if???
+        // Example of use: npx @testomatio/reporter run "npx jest" --filter "coverage:file=coverage/coverage.yml,diff=master"
+        const options = pipeOptions.split(',');
+        const coverageParams = {};
+
+        for (const option of options) {
+          const [key, value] = option.split('=');
+          if (key && value) {
+            coverageParams[key.trim()] = value.trim();
+          }
         }
-      } catch (err) {
-        console.log(APP_PREFIX, err);
+
+        try {
+          if (!coverageParams?.file) {
+            console.log(APP_PREFIX,
+              '🚫 Missing required parameter: "file".\n' +
+              '👉 When using Coverage task: you must provide a file path like: "coverage:file=coverage.yml"'
+            );
+            return;
+          }
+
+          process.env.COVERAGE_FILEPATH = coverageParams.file;
+
+          if (coverageParams?.diff) {
+            process.env.COVERAGE_BRANCH = coverageParams.diff; // in case if no "diff" set - "master " branch used as default
+          }
+
+          const tests = await client.prepareRun({ pipe, pipeOptions });
+          
+          if (!tests) return;
+          
+          const grepPattern = [...tests].join('|');
+          debug(`Full "grep" command: --grep "(${grepPattern})"`);
+
+          command += ` --grep "(${grepPattern})"`;
+        }
+        catch (err) {
+          console.log(APP_PREFIX, err);
+          return;
+        }
+      }
+      else if (pipe === 'testomatio') {
+        // Example of use: npx @testomatio/reporter run "npx jest" --filter "testomatio:tag-name=frontend"
+        try {
+          const tests = await client.prepareRun({ pipe, pipeOptions });
+          if (tests && tests.length > 0) {
+            command += ` --grep (${tests.join('|')})`;
+          }
+        } 
+        catch (err) {
+          console.log(APP_PREFIX, err);
+          return;
+        }
+      }
+      else {
+        console.log(APP_PREFIX,
+          `🚫 Unsupported --filter mode: "${pipe}".\n` +
+          '✅ Supported formats:\n' +
+          '   • "coverage:<options>" (e.g., --filter="coverage:file=coverage.yml")\n' +
+          '   • "testomatio:<options>" (e.g., --filter="testomatio:tag-name=smoke")\n\n' +
+          '👉 Please refer to the documentation for supported options and usage examples.\n'
+        );
+        return;
       }
     }
 
     console.log(APP_PREFIX, `🚀 Running`, pc.green(command));
+
+    debug("Full command text:", command.split(' '));
 
     const runTests = async () => {
       const testCmds = command.split(' ');

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -111,15 +111,16 @@ program
           return;
         }
 
+        const grepPattern = tests.join('|');
+        command += ` --grep "(${grepPattern})"`;
+
+        debug(`Full "grep" command: --grep "(${grepPattern})"`);
+
         if(opts.filterList) {
-          console.log(APP_PREFIX, pc.green(`Matched test/suite IDs: ${tests}`));
+          console.log(APP_PREFIX, pc.blue(`Matched test/suite IDs: ${tests}`));
+          console.log(APP_PREFIX, pc.green(`Full Running Command: ${command}`));
           return;
         }
-
-        const grepPattern = tests.join('|');
-        debug(`Full "grep" command: --grep "(${grepPattern})"`);
-        
-        command += ` --grep "(${grepPattern})"`;
       } 
       catch (err) {
         console.log(APP_PREFIX, err.message || err);

--- a/src/client.js
+++ b/src/client.js
@@ -8,7 +8,6 @@ import path from 'path';
 import { fileURLToPath } from 'node:url';
 import { S3Uploader } from './uploader.js';
 import { readLatestRunId, storeRunId, validateSuiteId, transformEnvVarToBoolean } from './utils/utils.js';
-import { parsePipeOptions } from './utils/pipe_utils.js';
 import { filesize as prettyBytes } from 'filesize';
 import { formatLogs, formatError, stripColors } from './utils/log-formatter.js';
 
@@ -69,22 +68,6 @@ class Client {
 
   async prepareRun(params) {
     const { pipe, pipeOptions } = params;
-    const parsedOptions = parsePipeOptions(pipeOptions);
-
-    // Handle Coverage pipe-specific setup
-    if (pipe === 'coverage') {
-      if (!parsedOptions.file) {
-        console.warn(APP_PREFIX,
-          '🚫 Missing required parameter: "file".\n' +
-          '👉 Usage: --filter="coverage:file=coverage.yml"'
-        );
-
-        return;
-      }
-  
-      process.env.COVERAGE_FILEPATH = parsedOptions?.file;
-      process.env.COVERAGE_BRANCH = parsedOptions?.diff || "master";
-    }
 
     this.pipes = await pipesFactory(params || this.paramsForPipesFactory || {}, this.pipeStore);
 
@@ -106,11 +89,8 @@ class Client {
       }
 
       // Run only the selected pipe
-      const result = await p.prepareRun(pipeOptions);
-
-      if (!result || result.length === 0) {
-        return [];
-      }
+      const rawResult = await p.prepareRun(pipeOptions);
+      const result = Array.isArray(rawResult) ? rawResult : [];
 
       debug('Execution tests list', result);
 

--- a/src/client.js
+++ b/src/client.js
@@ -65,6 +65,7 @@ class Client {
    * array containing the prepared execution list,
    * or resolves to undefined if no valid results are found or if all pipes are disabled.
    */
+  //TODO: need to find where we use client.prepareRun() method???
   async prepareRun(params) {
     this.pipes = await pipesFactory(params || this.paramsForPipesFactory || {}, this.pipeStore);
     const { pipe, pipeOptions } = params;
@@ -74,22 +75,19 @@ class Client {
     }
 
     try {
-      const filterPipe = this.pipes.find(p => p.constructor.name.toLowerCase() === `${pipe.toLowerCase()}pipe`);
+      const p = this.pipes.find(p => p.constructor.name.toLowerCase() === `${pipe.toLowerCase()}pipe`);
+      // const p = this.pipes.find(p => p.id === `${pipe.toLowerCase()}`); TODO: as future updates
 
-      if (!filterPipe?.isEnabled) {
-        // TODO:for the future for the another pipes
+      if (!p?.isEnabled) {
         console.warn(
           APP_PREFIX,
-          `At the moment processing is available only for the "testomatio" key. Example: "testomatio:tag-name=xxx"`,
+          "🚫 No active pipes were found in the system. Execution aborted!"
         );
         return;
       }
 
-      const results = await Promise.all(
-        this.pipes.map(async p => ({ pipe: p.toString(), result: await p.prepareRun(pipeOptions) })),
-      );
-
-      const result = results.filter(p => p.pipe.includes('Testomatio'))[0]?.result;
+      // Run only the selected pipe
+      const result = await p.prepareRun(pipeOptions);
 
       if (!result || result.length === 0) {
         return;

--- a/src/client.js
+++ b/src/client.js
@@ -81,12 +81,12 @@ class Client {
         return;
       }
   
-      process.env.COVERAGE_FILEPATH = parsedOptions.file;
-      process.env.COVERAGE_BRANCH = parsedOptions.diff || 'master';
+      process.env.COVERAGE_FILEPATH = parsedOptions?.file;
+      process.env.COVERAGE_BRANCH = parsedOptions?.diff || "master";
     }
 
     this.pipes = await pipesFactory(params || this.paramsForPipesFactory || {}, this.pipeStore);
-    
+
     // all pipes disabled, skipping
     if (!this.pipes.some(p => p.isEnabled)) {
       return Promise.resolve();
@@ -108,7 +108,7 @@ class Client {
       const result = await p.prepareRun(pipeOptions);
 
       if (!result || result.length === 0) {
-        return;
+        return [];
       }
 
       debug('Execution tests list', result);

--- a/src/client.js
+++ b/src/client.js
@@ -7,7 +7,8 @@ import { glob } from 'glob';
 import path from 'path';
 import { fileURLToPath } from 'node:url';
 import { S3Uploader } from './uploader.js';
-import { transformEnvVarToBoolean, readLatestRunId, storeRunId, validateSuiteId, parsePipeOptions } from './utils/utils.js';
+import { formatStep, truncate, readLatestRunId, storeRunId, validateSuiteId } from './utils/utils.js';
+import { parsePipeOptions } from './utils/pipe_utils.js';
 import { filesize as prettyBytes } from 'filesize';
 import { formatLogs, formatError, stripColors } from './utils/log-formatter.js';
 

--- a/src/client.js
+++ b/src/client.js
@@ -7,7 +7,7 @@ import { glob } from 'glob';
 import path from 'path';
 import { fileURLToPath } from 'node:url';
 import { S3Uploader } from './uploader.js';
-import { readLatestRunId, storeRunId, validateSuiteId, transformEnvVarToBoolean } from './utils/utils.js';
+import { transformEnvVarToBoolean, readLatestRunId, storeRunId, validateSuiteId, parsePipeOptions } from './utils/utils.js';
 import { filesize as prettyBytes } from 'filesize';
 import { formatLogs, formatError, stripColors } from './utils/log-formatter.js';
 
@@ -65,10 +65,28 @@ class Client {
    * array containing the prepared execution list,
    * or resolves to undefined if no valid results are found or if all pipes are disabled.
    */
-  //TODO: need to find where we use client.prepareRun() method???
+
   async prepareRun(params) {
-    this.pipes = await pipesFactory(params || this.paramsForPipesFactory || {}, this.pipeStore);
     const { pipe, pipeOptions } = params;
+    const parsedOptions = parsePipeOptions(pipeOptions);
+
+    // Handle Coverage pipe-specific setup
+    if (pipe === 'coverage') {
+      if (!parsedOptions.file) {
+        console.warn(APP_PREFIX,
+          '🚫 Missing required parameter: "file".\n' +
+          '👉 Usage: --filter="coverage:file=coverage.yml"'
+        );
+
+        return;
+      }
+  
+      process.env.COVERAGE_FILEPATH = parsedOptions.file;
+      process.env.COVERAGE_BRANCH = parsedOptions.diff || 'master';
+    }
+
+    this.pipes = await pipesFactory(params || this.paramsForPipesFactory || {}, this.pipeStore);
+    
     // all pipes disabled, skipping
     if (!this.pipes.some(p => p.isEnabled)) {
       return Promise.resolve();

--- a/src/client.js
+++ b/src/client.js
@@ -7,7 +7,7 @@ import { glob } from 'glob';
 import path from 'path';
 import { fileURLToPath } from 'node:url';
 import { S3Uploader } from './uploader.js';
-import { formatStep, truncate, readLatestRunId, storeRunId, validateSuiteId } from './utils/utils.js';
+import { readLatestRunId, storeRunId, validateSuiteId, transformEnvVarToBoolean } from './utils/utils.js';
 import { parsePipeOptions } from './utils/pipe_utils.js';
 import { filesize as prettyBytes } from 'filesize';
 import { formatLogs, formatError, stripColors } from './utils/log-formatter.js';

--- a/src/client.js
+++ b/src/client.js
@@ -69,6 +69,17 @@ class Client {
   async prepareRun(params) {
     const { pipe, pipeOptions } = params;
 
+    // ❗ Validation: pipe is required
+    if (!pipe || !pipeOptions) {
+      console.warn(`❗ No valid pipe found in filter cmd. Expected format: <pipe>:<options>
+      Examples:
+        --filter "testomatio:tag-name=frontend"
+        --filter "coverage:file=coverage.yml"
+        --filter-list "coverage:file=coverage.yml"
+      Received: "${params}"`);
+      return;
+    }
+
     this.pipes = await pipesFactory(params || this.paramsForPipesFactory || {}, this.pipeStore);
 
     // all pipes disabled, skipping

--- a/src/pipe/coverage.js
+++ b/src/pipe/coverage.js
@@ -38,37 +38,40 @@ class CoveragePipe { // or Changes for the future???
     constructor(params, store) {
         this.id = 'coverage'; // as future updates -> find by id in client.js
         this.store = store || {};
-        this.isEnabled = false;
         this.branch = undefined;
         this.isDefaultGitChanges = false; // COVERAGE_BY_DEFAULT_GIT_FILE env uses only for unit tests
+        this.isEnabled = false;
+
+        const { pipeOptions } = params;
+        const options = parsePipeOptions(pipeOptions || "");
+        debug("Pipe options", options);
+
+        // this.isDefaultGitChanges - COVERAGE_BY_DEFAULT_GIT_FILE env uses only for unit tests
+        this.isDefaultGitChanges = process.env.COVERAGE_BY_DEFAULT_GIT_FILE === '1'? true : false;
+        this.coverageFilePath = options?.file || process.env.COVERAGE_FILEPATH || undefined ;
+
+        if (!this.coverageFilePath) return;
+
+        this.branch = options?.diff || process.env.COVERAGE_BRANCH || this.#GIT.default_branch;
+        this.isBranchDefault = !options.diff && !process.env.COVERAGE_BRANCH;
+        
+        if (this.isBranchDefault) {
+            console.log(
+                APP_PREFIX,
+                `🟡 No "diff" branch provided. That's why we use default one = "${this.branch}".\n` +
+                '👉 You can set it via --filter "coverage:file=coverage.yml,diff=your-branch"'
+            );
+        }
 
         // Client config section
         this.formattedDate = new Date().toISOString().replace(/T/, '-').replace(/:/g, '-').split('.')[0];
         this.title = process.env.TESTOMATIO_TITLE || `Testomatio Coverage Test Execution - ${this.formattedDate}`;
         this.apiKey = process.env['INPUT_TESTOMATIO-KEY'] || config.TESTOMATIO;
 
-        // this.isDefaultGitChanges - COVERAGE_BY_DEFAULT_GIT_FILE env uses only for unit tests
-        this.isDefaultGitChanges = process.env.COVERAGE_BY_DEFAULT_GIT_FILE === '1'? true : false;
-        this.coverageFilePath = process.env.COVERAGE_FILEPATH || undefined;
-        
-        if (!this.coverageFilePath) return;
-
         this.url = params.testomatioUrl || process.env.TESTOMATIO_URL || 'https://app.testomat.io';
-        const proxyUrl = process.env.HTTP_PROXY || process.env.HTTPS_PROXY;
+        const proxyUrl = process.env.HTTP_PROXY || process.env.HTTPS_PROXY || null;
         const proxy = proxyUrl ? new URL(proxyUrl) : null;
 
-        this.branch = process.env.COVERAGE_BRANCH ? process.env.COVERAGE_BRANCH : this.#GIT.default_branch;
-        
-        if (!process.env.COVERAGE_BRANCH) {
-            console.log(
-                APP_PREFIX,
-                `🟡 No "diff" branch provided. That's why we use default branch = "${this.#GIT.default_branch}".\n` +
-                '👉 You can set it via --filter "coverage:file=coverage.yml,diff=your-branch"'
-            );
-        }
-
-        // In case if we have all needed data
-        this.isEnabled = true;
         // Create a new instance of gaxios with a custom config
         this.client = new Gaxios({
             baseURL: `${this.url.trim()}`,
@@ -95,6 +98,9 @@ class CoveragePipe { // or Changes for the future???
             }
         });
 
+        // In case if we have all needed data 
+        this.isEnabled = true;
+
         debug('Coverage Pipe initialized', {
             branch: this.branch,
             coverageFilePath: this.coverageFilePath,
@@ -112,7 +118,7 @@ class CoveragePipe { // or Changes for the future???
         debug(`Coverage Pipe: is Enabled = ${this.isEnabled}`);
     }
 
-    async prepareRun(opts) {
+    async prepareRun(opts) {       
         // Reset internal mutable state for isolation
         this.tests.clear();
         this.suiteIds.clear();
@@ -121,46 +127,39 @@ class CoveragePipe { // or Changes for the future???
 
         if (!this.isEnabled) return [];
 
-        const parsedOptions = parsePipeOptions(opts);
+        // Step 1: Validate coverage file path & Git changes & Coverage parsing
+        if (!this.getGitChangedFiles()?.validateCoverageFile()?.parseCoverageFile()) return [];
 
-        const { file } = parsedOptions;
+        // Step 2: Extract all available tests and compare with coverage file
+        const lines = await this.extractRelevantTestsFromChanges();
 
-        if (file) {
-            console.log(APP_PREFIX, `📦 Using branch: ${this.branch}`);
-            // Step 1: Validate coverage file path & Git changes & Coverage parsing
-            if (!this.getGitChangedFiles()?.validateCoverageFile()?.parseCoverageFile()) return [];
+        if (lines.size === 0) {
+            console.log(APP_PREFIX, 'ℹ️  No matching entries in coverage file for provided Git changes.');
+            return [];
+        }
 
-            // Step 2: Extract all available tests and compare with coverage file
-            const lines = await this.extractRelevantTestsFromChanges();
+        // Step 3: Handle tag labels tests from the server
+        // if (this.tagLabels && this.tagLabels.size > 0) { //TODO: in case if we add labels in future!!!
+        if (this.tagLabels.size > 0) {
+            for (const tag of this.tagLabels) {
+                const tagType = 'tag';
+                const tests = await this.#getTestomatioTestsByParam(tagType, tag);
 
-            if (lines.size === 0) {
-                console.log(APP_PREFIX, 'ℹ️  No matching entries in coverage file for provided Git changes.');
-                return [];
-            }
+                if (!tests) return [];
 
-            // Step 3: Handle tag labels tests from the server
-            // if (this.tagLabels && this.tagLabels.size > 0) { //TODO: in case if we add labels in future!!!
-            if (this.tagLabels.size > 0) {
-                for (const tag of this.tagLabels) {
-                    const tagType = 'tag';
-                    const tests = await this.#getTestomatioTestsByParam(tagType, tag);
+                console.log(
+                    APP_PREFIX, 
+                    `✅ We found ${tests.length === 1 ? 'one entry' : `${tests.length} (test/suite) entries`}` +
+                    ' in Testomat.io service side.'
+                );
+                
+                tests.forEach(testId => this.tests.add(testId));
+            }  
+        }
 
-                    if (!tests) return [];
-
-                    console.log(
-                        APP_PREFIX, 
-                        `✅ We found ${tests.length === 1 ? 'one entry' : `${tests.length} (test/suite) entries`}` +
-                        ' in Testomat.io service side.'
-                    );
-                    
-                    tests.forEach(testId => this.tests.add(testId));
-                }  
-            }
-
-            if (this.tests.size === 0) {
-                console.log(APP_PREFIX, 'ℹ️  No tests found for execution based on Git changes.');            
-                return [];
-            }
+        if (this.tests.size === 0) {
+            console.log(APP_PREFIX, 'ℹ️  No tests found for execution based on Git changes.');            
+            return [];
         }
 
         this.results = [...this.tests];

--- a/src/pipe/coverage.js
+++ b/src/pipe/coverage.js
@@ -1,0 +1,398 @@
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+import { execSync } from 'child_process';
+import { Gaxios } from 'gaxios';
+import { minimatch } from 'minimatch';
+import pc from 'picocolors';
+import { APP_PREFIX, AXIOS_TIMEOUT, REPORTER_REQUEST_RETRIES } from '../constants.js';
+import { parseFilterParams, generateFilterRequestParams } from '../utils/pipe_utils.js';
+import { config } from '../config.js';
+import createDebugMessages from 'debug';
+
+const debug = createDebugMessages('@testomatio/reporter:pipe:csv');
+
+// TODO: Add unit tests like for testomatio_pipe_tests !!! after deeper testing
+
+// Example of use 'coverage:file=coverage/coverage.yml,diff=master' cmd:
+// | Option | Git command | Notes |
+// | --- | --- | --- |
+// | --filter "coverage:file=coverage/coverage.yml,diff=new-branch" | ✅ git diff new-branch --name-only | - |
+// | --filter "coverage:file=diff=master,coverage.yml" | ✅ git diff master --name-only | - |
+// | --filter "coverage:file=coverage/coverage.yml" | ✅ git diff master --name-only | default branch = "master" |
+// | --filter "coverage:file=coverage.yml,dif=noexist-branch" | ❌ Git command failed ...| - |
+// | --filter "coverage:file=no-exist-coverage.yml" | ❌ Coverage file not found: <>filename>.yml | - |
+// | --filter "coverage:filepath=coverage.yml" | 🚫 Missing required parameter: "file"... | - |
+// | --filter "coverage:diff=my-branch" | 🚫 Missing required parameter: "file"...| - |
+
+//maybe GitChanges or GitCoverage
+class CoveragePipe { // or Changes for the future???
+    #GIT = {
+        default_branch: 'master',
+        diff_command: 'git diff',
+        only_file_opt: '--name-only',
+        uncommitted_marker: 'uncommitted',
+    };
+
+    constructor(params, store) {
+        this.id = 'coverage'; // as future updates -> find by id in clien.js
+        this.store = store || {};
+        this.isEnabled = false;
+
+        // Client config section
+        this.formattedDate = new Date().toISOString().replace(/T/, '-').replace(/:/g, '-').split('.')[0];
+        this.title = process.env.TESTOMATIO_TITLE || `Testomatio Coverage Test Execution - ${this.formattedDate}`;
+        this.apiKey = process.env['INPUT_TESTOMATIO-KEY'] || config.TESTOMATIO;
+
+        this.coverageFilePath = process.env.COVERAGE_FILEPATH || undefined;
+        // TODO: this.gitCommitOption = params.changes || this.#GIT.uncommitted_marker; // Default = "uncommitted" if not provided
+        
+        if (!process.env.COVERAGE_BRANCH) {
+            console.log(
+                APP_PREFIX,
+                `🟡 No "diff" branch provided. That's why we use default branch = "${this.#GIT.default_branch}".\n` +
+                '👉 You can set it via --filter "coverage:file=coverage.yml,diff=your-branch"'
+            );
+        }
+
+        this.branch = process.env.COVERAGE_BRANCH ? process.env.COVERAGE_BRANCH : this.#GIT.default_branch;
+
+        debug('Coverage Pipe: ', 'Git Branch - ', this.branch, ', Coverage filepath - ', this.coverageFilePath);
+        
+        if (!this.coverageFilePath) return;
+        
+        this.url = params.testomatioUrl || process.env.TESTOMATIO_URL || 'https://app.testomat.io';
+        const proxyUrl = process.env.HTTP_PROXY || process.env.HTTPS_PROXY;
+        const proxy = proxyUrl ? new URL(proxyUrl) : null;
+
+        // In case if we have all needed data
+        this.isEnabled = true;
+        // Create a new instance of gaxios with a custom config
+        this.client = new Gaxios({
+            baseURL: `${this.url.trim()}`,
+            timeout: AXIOS_TIMEOUT,
+            proxy: proxy ? proxy.toString() : undefined,
+            retry: true,
+            retryConfig: {
+            retry: REPORTER_REQUEST_RETRIES.retriesPerRequest,
+            retryDelay: REPORTER_REQUEST_RETRIES.retryTimeout,
+            httpMethodsToRetry: ['GET','PUT','HEAD','OPTIONS','DELETE','POST'],
+            shouldRetry: (error) => {
+                if (!error.response) return false;
+                switch (error.response?.status) {
+                case 400: // Bad request (probably wrong API key)
+                case 404: // Test not matched
+                case 429: // Rate limit exceeded
+                case 500: // Internal server error
+                    return false;
+                default:
+                    break;
+                }
+                return error.response?.status >= 401; // Retry on 401+ and 5xx
+            }
+            }
+        });
+
+        this.parsedCoverage = {};
+        this.changedFiles = [];
+        this.matchedLines = new Set();        
+        this.tests = new Set();
+        this.suiteIds = new Set();
+        this.tagLabels = new Set();
+
+        this.results = [];
+
+        debug(`Coverage Pipe: is Enabled = ${this.isEnabled}`);
+    }
+
+    async prepareRun(params) {
+        if (!this.isEnabled) return [];
+
+        // Step 1: Validate coverage file path & Git changes & Coverage parsing
+        if (!this.getGitChangedFiles()?.validateCoverageFile()?.parseCoverageFile()) return;
+
+        // Step 2: Extract all available tests and compare with coverage file
+        const lines = await this.extractRelevantTestsFromChanges();
+
+        if (lines.size === 0) {
+            console.log(APP_PREFIX, 'ℹ️  No matching entries in coverage file for provided Git changes.');
+            return;
+        }
+
+        if (this.tests.size === 0) {
+            console.log(APP_PREFIX, 'ℹ️  No tests found for execution based on Git changes.');            
+            return;
+        }
+
+        // Step 2: Handle tag labels tests from the server
+        if (this.tagLabels && this.tagLabels.size > 0) {
+            for (const tag of this.tagLabels) {
+                const tests = await this.#getTestomatioTestsByParam(`tag-name=${tag}`);
+
+                if (!tests) return;
+                
+                tests.forEach(testId => this.tests.add(testId));
+            }
+        }
+
+        console.log(APP_PREFIX, `✅ We found ${this.tests.size === 1 ? 'one test' : `${this.tests.size} tests`} in Testomat.io side.`);
+        console.log(pc.green(`📝 Retrieving a list of all modified tests from files is complete! Start running tests...`));        
+        
+        return this.tests;
+    }
+
+    addTest(test) {} // WIP*???
+
+    async createRun() {}
+
+    updateRun() {}
+
+    async finishRun(runParams) {}
+
+    toString() {
+        return 'Coverage Reporter';
+    }
+
+    /**
+     * Fetches a list of tests from the Testomat.io server based on a given filter parameter.
+     *
+     * The method parses the provided filter (`type=id`), builds the appropriate request parameters,
+     * sends a GET request to the Testomat.io `/api/test_grep` endpoint, and returns the matching tests.
+     *
+     * If the filter is invalid, no query is generated, or the server responds with no matching tests,
+     * it logs relevant information and returns `undefined`.
+     *
+     * @async function
+     * @param {string} param - The filter string in the format like `tag-name=smoke`.
+     * @returns {Promise<Array<Object>|undefined>} Resolves to an array of test objects if found, otherwise `undefined`.
+     */
+    async #getTestomatioTestsByParam(param) {
+        const { type, id } = parseFilterParams(param);
+
+        // Get extra tests from the server
+        try {
+            const q = generateFilterRequestParams({
+                type,
+                id,
+                apiKey: this.apiKey.trim(),
+            });
+
+            if (!q) {
+                return;
+              }
+
+            const resp = await this.client.request({
+                method: 'GET',
+                url: '/api/test_grep',
+                ...q,
+            });
+
+            if (!Array.isArray(resp.data?.tests) && resp.data?.tests?.length === 0) {
+                console.log(APP_PREFIX, `🔍 No test by ${type}=${id} were found on the Testomat.io server side!`);
+                return undefined;
+            }
+
+            return resp.data.tests;
+        } 
+        catch (err) {
+            console.error(APP_PREFIX, `🚩 Error getting available tests from the Testomat.io by "test_grep" option: ${err}`);
+            return undefined;
+        }
+    }
+
+    /**
+     * Executes a Git command to retrieve a list of changed files.
+     *
+     * @param {string} cmd - The Git command to execute.
+     * @returns {string[]} An array of changed file paths. Returns an empty array if an error occurs
+     * (e.g., not a Git repository or command failure).
+     */
+    #getChangedFilesFromGit(cmd) {
+        try {
+            const result = execSync(cmd, {
+                encoding: 'utf-8',
+                stdio: ['pipe', 'pipe', 'ignore']
+            });
+    
+            return result
+                .split('\n')
+                .map(f => f.trim())
+                .filter(Boolean);
+        } 
+        catch (err) {
+            const errorMessage = err.message || '';
+            // Git edge: Not a git repository or other error
+            if (errorMessage.includes('Not a git repository')) {
+                console.error(APP_PREFIX, '❌ Error: This folder is not a Git repository.');
+            } 
+            else {
+                throw new Error(`❌ Git command failed ("${cmd}"):\n`, errorMessage);
+            }
+    
+            return [];
+        }
+    }
+
+    /**
+     * Builds a Git command string to list file changes between the current state 
+     * and a specified Git branch using `git diff --name-only`.
+     * 
+     * Private pipe function
+     * @throws {Error} Throws an error if `this.branch` is not defined.
+     * @returns {string} A Git command string, e.g., 'git diff <branch> --name-only'.
+     */
+    #buildGitCommand() {
+        if (!this.branch) throw new Error(`❌ Invalid changes option for setted branch!`);
+        
+        return `git diff ${this.branch} --name-only`; // Example: 'git diff <master> --name-only' 
+    }
+
+    /**
+     * Retrieves the list of files changed in the current Git working directory 
+     * compared to a specified branch.
+     *
+     * This method builds a Git diff command and attempts to retrieve the changed 
+     * files using that command. It logs helpful information and errors during the process.
+     *
+     * If no changed files are found, or an error occurs at any stage, the method logs 
+     * the issue and returns `undefined`.
+     *
+     * @returns {this | undefined} Returns the current instance (`this`) if changed files are found; otherwise, returns `undefined`.
+     */
+    getGitChangedFiles() {
+        let cmd;
+
+        try {
+            cmd = this.#buildGitCommand();
+        } 
+        catch (err) {
+            console.error(APP_PREFIX, err.message);
+            return undefined;
+        }
+        
+        console.error(APP_PREFIX, `ℹ️  We will use '${cmd}' Git command.`);
+
+        try {
+            this.changedFiles =  this.#getChangedFilesFromGit(cmd);
+
+            if (this.changedFiles.length === 0) {
+                console.log(APP_PREFIX, 'ℹ️  No files changed in the latest Git commit. Skipping coverage processing.');
+                return undefined;
+            }
+        }
+        catch (err) {
+            console.error(APP_PREFIX, err.message);
+            console.error(APP_PREFIX, "🔍 Pls, check this Git command manually to understand the original problem.");
+            return undefined;
+        }        
+
+        console.log(APP_PREFIX, `📑  GIT changed files:\n  - ${this.changedFiles.join('\n  - ')}`);        
+        return this;
+    }
+
+    /**
+     * Validates the coverage file path (stored in `this.coverageFilePath`).
+     *
+     * This method checks:
+     * - That the file exists on disk.
+     * - That it is a regular file (not a directory or special file).
+     * - That it has a `.yml` extension to ensure it's a YAML file.
+     *
+     * Logs descriptive error messages for any failures.
+     *
+     * @returns {this | undefined} "true" in case if coverage file is valid and we can keep going; otherwise, `undefined`.
+     */
+    validateCoverageFile() {
+        // Validate the presence of the coverage filepath
+        if (!fs.existsSync(this.coverageFilePath)) {
+            console.log(APP_PREFIX, '❌ Coverage file not found:', this.coverageFilePath);
+            return undefined;
+        }
+
+        // Ensure the given path is a file (not a directory or other type)
+        const stat = fs.statSync(this.coverageFilePath);
+        if (!stat.isFile()) {
+            console.log(APP_PREFIX, '❌ Provided coverage path is not a file:', this.coverageFilePath);
+            return undefined;
+        }
+
+        // Validate the file extension to be ".yml" to ensure it's a YAML file
+        if (path.extname(this.coverageFilePath) !== ".yml") {
+            console.log(APP_PREFIX, '❌ Coverage file must have a .yml extension:', this.coverageFilePath);
+            return undefined;
+        }
+
+        debug('Coverage file validation is OK!');
+
+        return this;
+    }
+
+    /**
+     * Parses the YAML coverage file (located at `this.coverageFilePath`) into a JavaScript object.
+     *
+     * - Reads the file content using UTF-8 encoding.
+     * - Parses it as YAML using the `yaml` library.
+     * - Stores the result in `this.parsedCoverage`.
+     * - If parsing fails, logs an error and returns `undefined`.
+     *
+     * @returns {this | undefined} The current parsed coverage yml file change lines, or "undefined" if parsing fails.
+     */
+    parseCoverageFile() {
+        try {
+            // Read the contents of the YAML file and attempt to parse the YAML into a JavaScript object
+            const rawYml = fs.readFileSync(this.coverageFilePath, 'utf8');
+            this.parsedCoverage = yaml.load(rawYml) || {};
+
+            debug(`Coverage filepath = ${this.coverageFilePath})`);
+            console.log(APP_PREFIX, `✅ Coverage file parsed successfully: ${this.coverageFilePath}`);
+
+            return this;
+        }
+        catch (err) {
+            console.error(APP_PREFIX, '❌ Failed to parse YAML:', err.message);
+            return undefined;
+        }
+    }
+
+    /**
+     * Extracts relevant test identifiers from changed files based on coverage mapping.
+     *
+     * Iterates over changed files and matches them against patterns in the parsed coverage data.
+     * For each match, it extracts test IDs or tags and stores them in corresponding sets:
+     * - Test IDs (starting with '@T' or '@S') are stored in `this.tests`
+     * - Tag labels (starting with 'tag:') are stored in `this.tagLabels`
+     * - Matched file paths are stored in `this.matchedLines`
+     *
+     * @returns {Promise <Set<string>>} A set of file paths that matched coverage patterns (`this.matchedLines`).
+     */
+    async extractRelevantTestsFromChanges() {         
+        for (const changedFile of this.changedFiles) {
+            for (const [pattern, ids] of Object.entries(this.parsedCoverage)) {
+              if (minimatch(changedFile, pattern)) {
+                this.matchedLines.add(changedFile);
+      
+                ids.forEach(id => {
+                    // Example: "@Tt74099t1"
+                    if (id.startsWith('@T')) {
+                        this.tests.add(id.slice(1));
+                    }
+                    // Example: "@Sd74099c1"
+                    else if (id.startsWith('@S')) {
+                        this.tests.add(id.slice(1));
+                    }
+                    // Example: "tag:@TestSmoke"
+                    else if (id.startsWith('tag')) {
+                        this.tagLabels.add(id.split(':')[1].slice(1));
+                    }
+                });
+              }
+            }
+        }
+
+        debug(`Matched lines: ${this.matchedLines}`);
+
+        return this.matchedLines;
+    }
+}
+
+export default CoveragePipe;

--- a/src/pipe/coverage.js
+++ b/src/pipe/coverage.js
@@ -6,21 +6,21 @@ import { Gaxios } from 'gaxios';
 import { minimatch } from 'minimatch';
 import pc from 'picocolors';
 import { APP_PREFIX, AXIOS_TIMEOUT, REPORTER_REQUEST_RETRIES } from '../constants.js';
-import { parseFilterParams, generateFilterRequestParams } from '../utils/pipe_utils.js';
+import { generateFilterRequestParams } from '../utils/pipe_utils.js';
+import { parsePipeOptions } from '../utils/utils.js';
 import { config } from '../config.js';
 import createDebugMessages from 'debug';
 
 const debug = createDebugMessages('@testomatio/reporter:pipe:csv');
 
-// TODO: Add unit tests like for testomatio_pipe_tests !!! after deeper testing
-
 // Example of use 'coverage:file=coverage/coverage.yml,diff=master' cmd:
 // | Option | Git command | Notes |
 // | --- | --- | --- |
 // | --filter "coverage:file=coverage/coverage.yml,diff=new-branch" | ✅ git diff new-branch --name-only | - |
-// | --filter "coverage:file=diff=master,coverage.yml" | ✅ git diff master --name-only | - |
+// | --filter "coverage:diff=master,file=coverage.yml" | ✅ git diff master --name-only | - |
 // | --filter "coverage:file=coverage/coverage.yml" | ✅ git diff master --name-only | default branch = "master" |
 // | --filter "coverage:file=coverage.yml,dif=noexist-branch" | ❌ Git command failed ...| - |
+// | --filter "coverage:file=coverage.yml,diff=noexist-branch" | ❌ Git command failed ...| because no branch found |
 // | --filter "coverage:file=no-exist-coverage.yml" | ❌ Coverage file not found: <>filename>.yml | - |
 // | --filter "coverage:filepath=coverage.yml" | 🚫 Missing required parameter: "file"... | - |
 // | --filter "coverage:diff=my-branch" | 🚫 Missing required parameter: "file"...| - |
@@ -32,20 +32,31 @@ class CoveragePipe { // or Changes for the future???
         diff_command: 'git diff',
         only_file_opt: '--name-only',
         uncommitted_marker: 'uncommitted',
+        test_defaultGitChangedFile: ['todomvc-tests/edit-todos_test.js'], // uses only for unit tests in "coverage_pipe_test.js" file
     };
 
     constructor(params, store) {
-        this.id = 'coverage'; // as future updates -> find by id in clien.js
+        this.id = 'coverage'; // as future updates -> find by id in client.js
         this.store = store || {};
         this.isEnabled = false;
+        this.branch = undefined;
+        this.isDefaultGitChanges = false; // COVERAGE_BY_DEFAULT_GIT_FILE env uses only for unit tests
 
         // Client config section
         this.formattedDate = new Date().toISOString().replace(/T/, '-').replace(/:/g, '-').split('.')[0];
         this.title = process.env.TESTOMATIO_TITLE || `Testomatio Coverage Test Execution - ${this.formattedDate}`;
         this.apiKey = process.env['INPUT_TESTOMATIO-KEY'] || config.TESTOMATIO;
 
+        this.isDefaultGitChanges = process.env.COVERAGE_BY_DEFAULT_GIT_FILE === '1'? true : false; // COVERAGE_BY_DEFAULT_GIT_FILE env uses only for unit tests
         this.coverageFilePath = process.env.COVERAGE_FILEPATH || undefined;
-        // TODO: this.gitCommitOption = params.changes || this.#GIT.uncommitted_marker; // Default = "uncommitted" if not provided
+        
+        if (!this.coverageFilePath) return;
+
+        this.url = params.testomatioUrl || process.env.TESTOMATIO_URL || 'https://app.testomat.io';
+        const proxyUrl = process.env.HTTP_PROXY || process.env.HTTPS_PROXY;
+        const proxy = proxyUrl ? new URL(proxyUrl) : null;
+
+        this.branch = process.env.COVERAGE_BRANCH ? process.env.COVERAGE_BRANCH : this.#GIT.default_branch;
         
         if (!process.env.COVERAGE_BRANCH) {
             console.log(
@@ -54,16 +65,6 @@ class CoveragePipe { // or Changes for the future???
                 '👉 You can set it via --filter "coverage:file=coverage.yml,diff=your-branch"'
             );
         }
-
-        this.branch = process.env.COVERAGE_BRANCH ? process.env.COVERAGE_BRANCH : this.#GIT.default_branch;
-
-        debug('Coverage Pipe: ', 'Git Branch - ', this.branch, ', Coverage filepath - ', this.coverageFilePath);
-        
-        if (!this.coverageFilePath) return;
-        
-        this.url = params.testomatioUrl || process.env.TESTOMATIO_URL || 'https://app.testomat.io';
-        const proxyUrl = process.env.HTTP_PROXY || process.env.HTTPS_PROXY;
-        const proxy = proxyUrl ? new URL(proxyUrl) : null;
 
         // In case if we have all needed data
         this.isEnabled = true;
@@ -93,6 +94,11 @@ class CoveragePipe { // or Changes for the future???
             }
         });
 
+        debug('Coverage Pipe initialized', {
+            branch: this.branch,
+            coverageFilePath: this.coverageFilePath,
+        });
+
         this.parsedCoverage = {};
         this.changedFiles = [];
         this.matchedLines = new Set();        
@@ -105,48 +111,65 @@ class CoveragePipe { // or Changes for the future???
         debug(`Coverage Pipe: is Enabled = ${this.isEnabled}`);
     }
 
-    async prepareRun(params) {
+    async prepareRun(opts) {
+        // Reset internal mutable state for isolation
+        this.tests.clear();
+        this.suiteIds.clear();
+        this.tagLabels.clear();
+        this.results = [];
+
         if (!this.isEnabled) return [];
 
-        // Step 1: Validate coverage file path & Git changes & Coverage parsing
-        if (!this.getGitChangedFiles()?.validateCoverageFile()?.parseCoverageFile()) return;
+        const parsedOptions = parsePipeOptions(opts);
 
-        // Step 2: Extract all available tests and compare with coverage file
-        const lines = await this.extractRelevantTestsFromChanges();
+        const { file } = parsedOptions;
 
-        if (lines.size === 0) {
-            console.log(APP_PREFIX, 'ℹ️  No matching entries in coverage file for provided Git changes.');
-            return;
-        }
+        if (file) {
+            console.log(APP_PREFIX, `📦 Using branch: ${this.branch}`);
+            // Step 1: Validate coverage file path & Git changes & Coverage parsing
+            if (!this.getGitChangedFiles()?.validateCoverageFile()?.parseCoverageFile()) return [];
 
-        if (this.tests.size === 0) {
-            console.log(APP_PREFIX, 'ℹ️  No tests found for execution based on Git changes.');            
-            return;
-        }
+            // Step 2: Extract all available tests and compare with coverage file
+            const lines = await this.extractRelevantTestsFromChanges();
 
-        // Step 2: Handle tag labels tests from the server
-        if (this.tagLabels && this.tagLabels.size > 0) {
-            for (const tag of this.tagLabels) {
-                const tests = await this.#getTestomatioTestsByParam(`tag-name=${tag}`);
-
-                if (!tests) return;
-                
-                tests.forEach(testId => this.tests.add(testId));
+            if (lines.size === 0) {
+                console.log(APP_PREFIX, 'ℹ️  No matching entries in coverage file for provided Git changes.');
+                return [];
             }
-        }
-        // TODO: switch log 'entry' to what??? - because we can have suite + tests: Safaa0ab4|Tc85d62e4
-        console.log(
-            APP_PREFIX, 
-            `✅ We found ${this.tests.size === 1 ? 'one entry' : `${this.tests.size} (test/suite) entries`}` +
-            ' in Testomat.io service side.'
-        );
 
-        console.log(pc.green(`📝 Retrieving a list of all modified tests from files is complete! Start running tests...`));        
+            // Step 3: Handle tag labels tests from the server
+            // if (this.tagLabels && this.tagLabels.size > 0) { //TODO: in case if we add labels in future!!!
+            if (this.tagLabels.size > 0) {
+                for (const tag of this.tagLabels) {
+                    const tagType = 'tag-name';
+                    const tests = await this.#getTestomatioTestsByParam(tagType, tag);
+
+                    if (!tests) return [];
+
+                    console.log(
+                        APP_PREFIX, 
+                        `✅ We found ${tests.length === 1 ? 'one entry' : `${tests.length} (test/suite) entries`}` +
+                        ' in Testomat.io service side.'
+                    );
+                    
+                    tests.forEach(testId => this.tests.add(testId));
+                }  
+            }
+
+            if (this.tests.size === 0) {
+                console.log(APP_PREFIX, 'ℹ️  No tests found for execution based on Git changes.');            
+                return [];
+            }
+
+            console.log(pc.green(`📝 Retrieving a list of all modified tests from files is complete! Start running tests...`));
+        }
+
+        this.results = [...this.tests]
         
-        return this.tests;
+        return this.results;
     }
 
-    addTest(data) {} // WIP* - no need for now???
+    addTest(data) {}
 
     async createRun() {}
 
@@ -168,18 +191,17 @@ class CoveragePipe { // or Changes for the future???
      * it logs relevant information and returns `undefined`.
      *
      * @async function
-     * @param {string} param - The filter string in the format like `tag-name=smoke`.
+     * @param {string} type - The filter string in the format like `tag-name` for tag by.
+     * @param {string} id - The filter string in the format like `smoke`.
      * @returns {Promise<Array<Object>|undefined>} Resolves to an array of test objects if found, otherwise `undefined`.
      */
-    async #getTestomatioTestsByParam(param) {
-        const { type, id } = parseFilterParams(param);
-
-        // Get extra tests from the server
+    async #getTestomatioTestsByParam(type, id) {
+        // Get tests from the server
         try {
             const q = generateFilterRequestParams({
                 type,
                 id,
-                apiKey: this.apiKey.trim(),
+                apiKey: this?.apiKey?.trim(),
             });
 
             if (!q) {
@@ -194,6 +216,7 @@ class CoveragePipe { // or Changes for the future???
 
             if (!Array.isArray(resp.data?.tests) && resp.data?.tests?.length === 0) {
                 console.log(APP_PREFIX, `🔍 No test by ${type}=${id} were found on the Testomat.io server side!`);
+                
                 return undefined;
             }
 
@@ -201,6 +224,7 @@ class CoveragePipe { // or Changes for the future???
         } 
         catch (err) {
             console.error(APP_PREFIX, `🚩 Error getting available tests from the Testomat.io by "test_grep" option: ${err}`);
+            
             return undefined;
         }
     }
@@ -278,11 +302,17 @@ class CoveragePipe { // or Changes for the future???
         console.error(APP_PREFIX, `ℹ️  We will use '${cmd}' Git command.`);
 
         try {
-            this.changedFiles =  this.#getChangedFilesFromGit(cmd);
+            // For clear unit testing process -> Like test_defaultGitChangedFile = todomvc-tests/edit-todos_test.js
+            if (this.isDefaultGitChanges) {
+                this.changedFiles = this.#GIT.test_defaultGitChangedFile;
+            }
+            else {
+                this.changedFiles =  this.#getChangedFilesFromGit(cmd);
 
-            if (this.changedFiles.length === 0) {
-                console.log(APP_PREFIX, 'ℹ️  No files changed in the latest Git commit. Skipping coverage processing.');
-                return undefined;
+                if (this.changedFiles.length === 0) {
+                    console.log(APP_PREFIX, 'ℹ️  No files changed in the latest Git commit. Skipping coverage processing.');
+                    return undefined;
+                }
             }
         }
         catch (err) {
@@ -370,7 +400,7 @@ class CoveragePipe { // or Changes for the future???
      *
      * @returns {Promise <Set<string>>} A set of file paths that matched coverage patterns (`this.matchedLines`).
      */
-    async extractRelevantTestsFromChanges() {         
+    async extractRelevantTestsFromChanges() {
         for (const changedFile of this.changedFiles) {
             for (const [pattern, ids] of Object.entries(this.parsedCoverage)) {
               if (minimatch(changedFile, pattern)) {

--- a/src/pipe/coverage.js
+++ b/src/pipe/coverage.js
@@ -143,7 +143,7 @@ class CoveragePipe { // or Changes for the future???
             // if (this.tagLabels && this.tagLabels.size > 0) { //TODO: in case if we add labels in future!!!
             if (this.tagLabels.size > 0) {
                 for (const tag of this.tagLabels) {
-                    const tagType = 'tag-name';
+                    const tagType = 'tag';
                     const tests = await this.#getTestomatioTestsByParam(tagType, tag);
 
                     if (!tests) return [];
@@ -210,7 +210,7 @@ class CoveragePipe { // or Changes for the future???
 
             if (!q) {
                 return;
-              }
+            }
 
             const resp = await this.client.request({
                 method: 'GET',

--- a/src/pipe/coverage.js
+++ b/src/pipe/coverage.js
@@ -4,7 +4,6 @@ import yaml from 'js-yaml';
 import { execSync } from 'child_process';
 import { Gaxios } from 'gaxios';
 import { minimatch } from 'minimatch';
-import pc from 'picocolors';
 import { APP_PREFIX, AXIOS_TIMEOUT, REPORTER_REQUEST_RETRIES } from '../constants.js';
 import { generateFilterRequestParams } from '../utils/pipe_utils.js';
 import { parsePipeOptions } from '../utils/pipe_utils.js';
@@ -162,10 +161,6 @@ class CoveragePipe { // or Changes for the future???
                 console.log(APP_PREFIX, 'ℹ️  No tests found for execution based on Git changes.');            
                 return [];
             }
-
-            console.log(
-                pc.green(`📝 Retrieving a list of all modified tests from files is complete! Start running tests...`)
-            );
         }
 
         this.results = [...this.tests];

--- a/src/pipe/coverage.js
+++ b/src/pipe/coverage.js
@@ -32,7 +32,8 @@ class CoveragePipe { // or Changes for the future???
         diff_command: 'git diff',
         only_file_opt: '--name-only',
         uncommitted_marker: 'uncommitted',
-        test_defaultGitChangedFile: ['todomvc-tests/edit-todos_test.js'], // uses only for unit tests in "coverage_pipe_test.js" file
+        // test_defaultGitChangedFile - uses only for unit tests in "coverage_pipe_test.js" file
+        test_defaultGitChangedFile: ['todomvc-tests/edit-todos_test.js'],
     };
 
     constructor(params, store) {
@@ -47,7 +48,8 @@ class CoveragePipe { // or Changes for the future???
         this.title = process.env.TESTOMATIO_TITLE || `Testomatio Coverage Test Execution - ${this.formattedDate}`;
         this.apiKey = process.env['INPUT_TESTOMATIO-KEY'] || config.TESTOMATIO;
 
-        this.isDefaultGitChanges = process.env.COVERAGE_BY_DEFAULT_GIT_FILE === '1'? true : false; // COVERAGE_BY_DEFAULT_GIT_FILE env uses only for unit tests
+        // this.isDefaultGitChanges - COVERAGE_BY_DEFAULT_GIT_FILE env uses only for unit tests
+        this.isDefaultGitChanges = process.env.COVERAGE_BY_DEFAULT_GIT_FILE === '1'? true : false;
         this.coverageFilePath = process.env.COVERAGE_FILEPATH || undefined;
         
         if (!this.coverageFilePath) return;
@@ -161,10 +163,12 @@ class CoveragePipe { // or Changes for the future???
                 return [];
             }
 
-            console.log(pc.green(`📝 Retrieving a list of all modified tests from files is complete! Start running tests...`));
+            console.log(
+                pc.green(`📝 Retrieving a list of all modified tests from files is complete! Start running tests...`)
+            );
         }
 
-        this.results = [...this.tests]
+        this.results = [...this.tests];
         
         return this.results;
     }
@@ -223,7 +227,10 @@ class CoveragePipe { // or Changes for the future???
             return resp.data.tests;
         } 
         catch (err) {
-            console.error(APP_PREFIX, `🚩 Error getting available tests from the Testomat.io by "test_grep" option: ${err}`);
+            console.error(
+                APP_PREFIX,
+                `🚩 Error getting available tests from the Testomat.io by "test_grep" option: ${err}`
+            );
             
             return undefined;
         }
@@ -286,7 +293,8 @@ class CoveragePipe { // or Changes for the future???
      * If no changed files are found, or an error occurs at any stage, the method logs 
      * the issue and returns `undefined`.
      *
-     * @returns {this | undefined} Returns the current instance (`this`) if changed files are found; otherwise, returns `undefined`.
+     * @returns {this | undefined} Returns the current instance (`this`) if changed files are found;
+     * otherwise, returns `undefined`.
      */
     getGitChangedFiles() {
         let cmd;
@@ -310,7 +318,11 @@ class CoveragePipe { // or Changes for the future???
                 this.changedFiles =  this.#getChangedFilesFromGit(cmd);
 
                 if (this.changedFiles.length === 0) {
-                    console.log(APP_PREFIX, 'ℹ️  No files changed in the latest Git commit. Skipping coverage processing.');
+                    console.log(
+                        APP_PREFIX,
+                        'ℹ️  No files changed in the latest Git commit. Skipping coverage processing.'
+                    );
+
                     return undefined;
                 }
             }
@@ -335,7 +347,8 @@ class CoveragePipe { // or Changes for the future???
      *
      * Logs descriptive error messages for any failures.
      *
-     * @returns {this | undefined} "true" in case if coverage file is valid and we can keep going; otherwise, `undefined`.
+     * @returns {this | undefined} "true" in case if coverage file is valid and we can keep going;
+     * otherwise, `undefined`.
      */
     validateCoverageFile() {
         // Validate the presence of the coverage filepath

--- a/src/pipe/coverage.js
+++ b/src/pipe/coverage.js
@@ -7,7 +7,7 @@ import { minimatch } from 'minimatch';
 import pc from 'picocolors';
 import { APP_PREFIX, AXIOS_TIMEOUT, REPORTER_REQUEST_RETRIES } from '../constants.js';
 import { generateFilterRequestParams } from '../utils/pipe_utils.js';
-import { parsePipeOptions } from '../utils/utils.js';
+import { parsePipeOptions } from '../utils/pipe_utils.js';
 import { config } from '../config.js';
 import createDebugMessages from 'debug';
 

--- a/src/pipe/coverage.js
+++ b/src/pipe/coverage.js
@@ -134,14 +134,19 @@ class CoveragePipe { // or Changes for the future???
                 tests.forEach(testId => this.tests.add(testId));
             }
         }
+        // TODO: switch log 'entry' to what??? - because we can have suite + tests: Safaa0ab4|Tc85d62e4
+        console.log(
+            APP_PREFIX, 
+            `✅ We found ${this.tests.size === 1 ? 'one entry' : `${this.tests.size} (test/suite) entries`}` +
+            ' in Testomat.io service side.'
+        );
 
-        console.log(APP_PREFIX, `✅ We found ${this.tests.size === 1 ? 'one test' : `${this.tests.size} tests`} in Testomat.io side.`);
         console.log(pc.green(`📝 Retrieving a list of all modified tests from files is complete! Start running tests...`));        
         
         return this.tests;
     }
 
-    addTest(test) {} // WIP*???
+    addTest(data) {} // WIP* - no need for now???
 
     async createRun() {}
 

--- a/src/pipe/index.js
+++ b/src/pipe/index.js
@@ -7,6 +7,7 @@ import GitHubPipe from './github.js';
 import GitLabPipe from './gitlab.js';
 import CsvPipe from './csv.js';
 import HtmlPipe from './html.js';
+import CoveragePipe from './coverage.js';
 import { BitbucketPipe } from './bitbucket.js';
 import { DebugPipe } from './debug.js';
 
@@ -48,6 +49,7 @@ export async function pipesFactory(params, opts) {
     new CsvPipe(params, opts),
     new HtmlPipe(params, opts),
     new BitbucketPipe(params, opts),
+    new CoveragePipe(params, opts),
     new DebugPipe(params, opts),
     ...extraPipes,
   ];

--- a/src/pipe/testomatio.js
+++ b/src/pipe/testomatio.js
@@ -129,17 +129,23 @@ class TestomatioPipe {
   async prepareRun(opts) {
     if (!this.isEnabled) return [];
 
-    const { type, id } = parseFilterParams(opts);
+    const clearOptions = parseFilterParams(opts);
+
+    if (!clearOptions) {
+      return [];
+    }
+
+    const { type, id } = clearOptions;
 
     try {
       const q = generateFilterRequestParams({
         type,
         id,
-        apiKey: this.apiKey.trim(),
+        apiKey: this?.apiKey?.trim(),
       });
 
       if (!q) {
-        return;
+        return [];
       }
 
       const resp = await this.client.request({

--- a/src/utils/pipe_utils.js
+++ b/src/utils/pipe_utils.js
@@ -58,6 +58,8 @@ function parseFilterParams(opts) {
   
   const validType = updateFilterType(type);
 
+  if (!validType) return undefined;
+
   return {
     type: validType,
     id,

--- a/src/utils/pipe_utils.js
+++ b/src/utils/pipe_utils.js
@@ -53,7 +53,9 @@ function generateFilterRequestParams(params) {
  *                   The object has properties "type" and "id".
  */
 function parseFilterParams(opts) {
-  const [type, id] = opts.split('=');
+  const [type, ...idParts] = opts.split('=');
+  const id = idParts.join('=');
+  
   const validType = updateFilterType(type);
 
   return {

--- a/src/utils/pipe_utils.js
+++ b/src/utils/pipe_utils.js
@@ -25,6 +25,12 @@ function setS3Credentials(artifacts) {
  * @returns {Object|null} - An object containing the generated request parameters, or null if the type is invalid.
  */
 function generateFilterRequestParams(params) {
+  // Defensive check: ensure params is an object
+  if (!params || typeof params !== 'object') {
+    console.error(APP_PREFIX, `Invalid parameters provided. Expected an object, got: ${typeof params}`);
+    return;
+  }
+
   const { type, id, apiKey } = params;
 
   if (!type) {
@@ -73,6 +79,8 @@ function parseFilterParams(opts) {
  *                            Returns undefined if the type is not valid.
  */
 function updateFilterType(type) {
+  if (!type || typeof type !== 'string') return;
+
   let typeLowerCase = type.toLowerCase();
 
   const filterTypes = ['tag-name', 'plan', 'label', 'jira-ticket'];
@@ -90,7 +98,7 @@ function updateFilterType(type) {
   ];
 
   if (!filterTypes.includes(typeLowerCase)) {
-    console.log(APP_PREFIX, `❗❗❗ Invalid "filter=${type}" start settings! Available option list: ${filterTypes}`);
+    console.log(APP_PREFIX, `❗❗❗ Invalid filter: "${type}" start settings! Available option list: ${filterTypes}`);
     return;
   }
 

--- a/src/utils/pipe_utils.js
+++ b/src/utils/pipe_utils.js
@@ -132,4 +132,40 @@ function fullName(t) {
   return line;
 }
 
-export { updateFilterType, parseFilterParams, generateFilterRequestParams, setS3Credentials, statusEmoji, fullName };
+/**
+ * Parses a comma-separated list of key-value pairs into an options object.
+ *
+ * The input string should be formatted as `"key1=value1,key2=value2,..."`.
+ * Whitespace around keys and values is trimmed. If the input is empty or undefined,
+ * an empty object is returned.
+ *
+ * @param {string} [optionsStr] - A comma-separated string of key=value pairs.
+ * @returns {Object} An object mapping option keys to their string values.
+ *
+ * @example
+ * parsePipeOptions('foo=bar,baz=qux');
+ * => Returns: { foo: 'bar', baz: 'qux' }
+ */
+function parsePipeOptions(optionsStr) {
+  const options = {};
+  if (!optionsStr) return options;
+
+  const pairs = optionsStr.split(',');
+  for (const pair of pairs) {
+    const [key, value] = pair.split('=');
+    if (key && value) {
+      options[key.trim()] = value.trim();
+    }
+  }
+  return options;
+}
+
+export { 
+  updateFilterType, 
+  parseFilterParams, 
+  generateFilterRequestParams, 
+  setS3Credentials, 
+  statusEmoji, 
+  fullName,
+  parsePipeOptions
+};

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -615,20 +615,6 @@ function truncate(s, size = 255) {
   return `${str.substring(0, size)}...`;
 }
 
-function parsePipeOptions(optionsStr) {
-  const options = {};
-  if (!optionsStr) return options;
-
-  const pairs = optionsStr.split(',');
-  for (const pair of pairs) {
-    const [key, value] = pair.split('=');
-    if (key && value) {
-      options[key.trim()] = value.trim();
-    }
-  }
-  return options;
-}
-
 export {
   ansiRegExp,
   truncate,
@@ -653,6 +639,5 @@ export {
   storeRunId,
   testRunnerHelper,
   transformEnvVarToBoolean,
-  validateSuiteId,
-  parsePipeOptions
+  validateSuiteId
 };

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -615,6 +615,20 @@ function truncate(s, size = 255) {
   return `${str.substring(0, size)}...`;
 }
 
+function parsePipeOptions(optionsStr) {
+  const options = {};
+  if (!optionsStr) return options;
+
+  const pairs = optionsStr.split(',');
+  for (const pair of pairs) {
+    const [key, value] = pair.split('=');
+    if (key && value) {
+      options[key.trim()] = value.trim();
+    }
+  }
+  return options;
+}
+
 export {
   ansiRegExp,
   truncate,
@@ -640,4 +654,5 @@ export {
   testRunnerHelper,
   transformEnvVarToBoolean,
   validateSuiteId,
+  parsePipeOptions
 };

--- a/tests/unit/pipes/coverage_pipe_test.js
+++ b/tests/unit/pipes/coverage_pipe_test.js
@@ -1,0 +1,342 @@
+import { expect } from 'chai';
+import ServerMock from 'mock-http-server';
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+import CoveragePipe from '../../../src/pipe/coverage.js';
+import { config } from '../../adapter/config/index.js';
+import { fileURLToPath } from 'url';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const { host, port, TESTOMATIO_URL, TESTOMATIO } = config;
+
+const TEMP_COVER_DIR = path.join(dirname, 'pipe-tmp');
+const TEMP_COVERAGE_FILE = path.join(TEMP_COVER_DIR, 'temp_coverage.yml');
+
+describe('CoveragePipe: general positive cases.', () => {
+    const server = new ServerMock({ host, port });
+    let coveragePipe;
+    let originalEnv;
+
+    before(done => {
+        // Ensure clean temp directory
+        if (!fs.existsSync(TEMP_COVER_DIR)) {
+            fs.mkdirSync(TEMP_COVER_DIR);
+            console.log(`[mock-tmp-folder]: tmp folder was created - ${TEMP_COVER_DIR}`);
+        }
+
+        process.env.COVERAGE_BY_DEFAULT_GIT_FILE = "1";
+        process.env.COVERAGE_FILEPATH = TEMP_COVERAGE_FILE;
+
+        coveragePipe = new CoveragePipe({
+            apiKey: TESTOMATIO,
+            testomatioUrl: TESTOMATIO_URL,
+            isBatchEnabled: false
+        });
+
+        server.start(() => {
+            console.log(`[mock-http-server]: Started at ${TESTOMATIO_URL}`);
+            done();
+        });
+    });
+
+    after(done => {
+        delete process.env.COVERAGE_FILEPATH;
+        delete process.env.TESTOMATIO_URL;
+        delete process.env['INPUT_TESTOMATIO-KEY'];
+        delete process.env.COVERAGE_BY_DEFAULT_GIT_FILE;
+
+        coveragePipe = undefined;
+
+        // Cleanup temp directory
+        if (fs.existsSync(TEMP_COVER_DIR)) {
+            fs.readdirSync(TEMP_COVER_DIR).forEach(file => {
+                fs.unlinkSync(path.join(TEMP_COVER_DIR, file));
+            });
+            fs.rmdirSync(TEMP_COVER_DIR);
+            console.log(`[mock-tmp-folder]: tmp folder was removed - ${TEMP_COVER_DIR}`);
+        }
+
+        server.stop(() => {
+            console.log(`[mock-http-server]: Stopped`);
+            done();
+        });
+    });
+
+    beforeEach(() => {
+        originalEnv = { ...process.env };
+        process.env.TESTOMATIO_URL = TESTOMATIO_URL;
+        process.env.COVERAGE_FILEPATH = TEMP_COVERAGE_FILE;
+        process.env['INPUT_TESTOMATIO-KEY'] = TESTOMATIO;
+    });
+
+    afterEach(() => {
+        process.env = originalEnv;
+
+        fs.readdirSync(TEMP_COVER_DIR).forEach(file => {
+            fs.unlinkSync(path.join(TEMP_COVER_DIR, file));
+        });
+    });
+
+    describe('coverage prepareRun() testing', () => {
+        it('should read coverage file and return matched test from file without server responce', async () => {
+            const testId = "@Ttest10";
+            // Create temp coverage file for this test
+            fs.writeFileSync(TEMP_COVERAGE_FILE, 
+            `
+            todomvc-tests/edit-todos_test.js:
+             - "${testId}"
+            `);
+
+            const result = await coveragePipe.prepareRun(`file=${TEMP_COVERAGE_FILE}`);
+            expect(result).to.deep.equal([testId.slice(1)]);
+        });
+
+        it('should read coverage file and return matched test from server responce only', async () => {
+            const serverTestIds= ['TStest1', 'TStest2'];
+            // Create temp coverage file for this test
+            fs.writeFileSync(TEMP_COVERAGE_FILE, 
+            `
+            todomvc-tests/edit-todos_test.js:
+             - "tag:@smoke"
+            `);
+
+            // Mock the API response
+            server.on({
+                method: 'GET',
+                path: '/api/test_grep',
+                reply: {
+                    status: 200,
+                    headers: { 'content-type': 'application/json' },
+                    body: JSON.stringify({
+                        tests: serverTestIds
+                    })
+                }
+            });
+
+            const result = await coveragePipe.prepareRun(`file=${TEMP_COVERAGE_FILE}`);
+            expect(result).to.have.members(serverTestIds);
+        });
+
+        it('should read coverage file and return matched test from file + server responce', async () => {
+            const testId = "@Ttest10";
+            const serverTestIds= ['TStest1', 'TStest2'];
+            // Create temp coverage file for the test
+            fs.writeFileSync(TEMP_COVERAGE_FILE, 
+            `
+            todomvc-tests/edit-todos_test.js:
+             - "${testId}"
+             - "tag:@smoke"
+            `);
+
+            // Mock the API response
+            server.on({
+                method: 'GET',
+                path: '/api/test_grep',
+                reply: {
+                    status: 200,
+                    headers: { 'content-type': 'application/json' },
+                    body: JSON.stringify({
+                        tests: serverTestIds
+                    })
+                }
+            });
+
+            const result = await coveragePipe.prepareRun(`file=${TEMP_COVERAGE_FILE}`);
+            const resArray = serverTestIds.concat(testId.slice(1));
+
+            expect(result).to.have.members(resArray);
+        });
+
+        it('should read coverage file and return an empty tests array if no Git match files', async () => {
+            const testId = "@Ttest10";
+            // Create temp coverage file for this test
+            fs.writeFileSync(TEMP_COVERAGE_FILE, 
+            `
+            todomvc-tests/create-todos_test.js:
+             - "${testId}"
+            `);
+
+            const result = await coveragePipe.prepareRun(`file=${TEMP_COVERAGE_FILE}`);
+            expect(result).to.deep.equal([]);
+        });
+
+        it('should read coverage file and return an empty tests array if no tests from server', async () => {
+            // Create temp coverage file for this test
+            fs.writeFileSync(TEMP_COVERAGE_FILE, 
+            `
+            todomvc-tests/edit-todos_test.js:
+             - "tag:@smoke"
+            `);
+
+            // Mock the API response
+            server.on({
+                method: 'GET',
+                path: '/api/test_grep',
+                reply: {
+                    status: 200,
+                    headers: { 'content-type': 'application/json' },
+                    body: JSON.stringify({
+                        tests: []
+                    })
+                }
+            });
+
+            const result = await coveragePipe.prepareRun(`file=${TEMP_COVERAGE_FILE}`);
+            expect(result).to.deep.equal([]);
+        });
+    });
+});
+
+describe('CoveragePipe general setup cases.', () => {
+    let coveragePipe;
+    let originalEnv;
+
+    before(done => {
+        // Ensure clean temp directory
+        if (!fs.existsSync(TEMP_COVER_DIR)) {
+            fs.mkdirSync(TEMP_COVER_DIR);
+            console.log(`[mock-tmp-folder]: tmp folder was created - ${TEMP_COVER_DIR}`);
+        }
+
+        done();
+    });
+
+    after(done => {
+        // Cleanup temp directory
+        if (fs.existsSync(TEMP_COVER_DIR)) {
+            fs.readdirSync(TEMP_COVER_DIR).forEach(file => {
+                fs.unlinkSync(path.join(TEMP_COVER_DIR, file));
+            });
+            fs.rmdirSync(TEMP_COVER_DIR);
+            console.log(`[mock-tmp-folder]: tmp folder was removed - ${TEMP_COVER_DIR}`);
+        }
+
+        done();
+    });
+
+    beforeEach(() => {
+        originalEnv = { ...process.env };
+        process.env.TESTOMATIO_URL = TESTOMATIO_URL;
+        process.env['INPUT_TESTOMATIO-KEY'] = TESTOMATIO;
+    });
+
+    afterEach(() => {
+        delete process.env.COVERAGE_FILEPATH;
+        delete process.env.COVERAGE_BRANCH;
+        delete process.env.COVERAGE_BY_DEFAULT_GIT_FILE;
+
+        coveragePipe = undefined;
+
+        fs.readdirSync(TEMP_COVER_DIR).forEach(file => {
+            fs.unlinkSync(path.join(TEMP_COVER_DIR, file));
+        });
+    });
+
+    describe('Coverage class - diff branch tests', () => {
+        it('by default we use git diff = "master" (COVERAGE_BRANCH)', async () => {
+            const branchName = "master";
+            
+            // Coverage pipe preparation
+            process.env.COVERAGE_FILEPATH = TEMP_COVERAGE_FILE;
+            process.env.COVERAGE_BRANCH = branchName;
+    
+            coveragePipe = new CoveragePipe({
+                apiKey: TESTOMATIO,
+                testomatioUrl: TESTOMATIO_URL,
+                isBatchEnabled: false
+            });
+
+            expect(coveragePipe.branch).to.equal(branchName);
+        });
+
+        it('user try to use any other diff = "test" (COVERAGE_BRANCH)', async () => {
+            const branchName = "my-test";
+
+            // Coverage pipe preparation
+            process.env.COVERAGE_FILEPATH = TEMP_COVERAGE_FILE;
+            process.env.COVERAGE_BRANCH = branchName;
+    
+            coveragePipe = new CoveragePipe({
+                apiKey: TESTOMATIO,
+                testomatioUrl: TESTOMATIO_URL,
+                isBatchEnabled: false
+            });
+
+            expect(coveragePipe.branch).to.equal(branchName);
+        });
+
+        it('by default we use diff = "master" in case if NO provided (COVERAGE_BRANCH)', async () => {
+            // Coverage pipe preparation
+            process.env.COVERAGE_FILEPATH = TEMP_COVERAGE_FILE;
+    
+            coveragePipe = new CoveragePipe({
+                apiKey: TESTOMATIO,
+                testomatioUrl: TESTOMATIO_URL,
+                isBatchEnabled: false
+            });
+
+            expect(coveragePipe.branch).to.equal("master");
+        });
+    });
+
+    describe('Coverage class - file tests', () => {
+        it('if COVERAGE_FILEPATH setup -> pipe is enabled', async () => {
+            const branchName = "master";
+            
+            // Coverage pipe preparation
+            process.env.COVERAGE_FILEPATH = TEMP_COVERAGE_FILE;
+            process.env.COVERAGE_BRANCH = branchName;
+    
+            coveragePipe = new CoveragePipe({
+                apiKey: TESTOMATIO,
+                testomatioUrl: TESTOMATIO_URL,
+                isBatchEnabled: false
+            });
+
+            expect(coveragePipe.isEnabled).to.equal(true);
+        });
+
+        it('if COVERAGE_FILEPATH is empty -> pipe is disabled', async () => {   
+            coveragePipe = new CoveragePipe({
+                apiKey: TESTOMATIO,
+                testomatioUrl: TESTOMATIO_URL,
+                isBatchEnabled: false
+            });
+
+            expect(coveragePipe.isEnabled).to.equal(false);
+        });
+
+        it('if COVERAGE_FILEPATH is empty -> pipe is disabled', async () => {
+            const branchName = "master";
+            
+            // Coverage pipe preparation
+            process.env.COVERAGE_BRANCH = branchName;
+    
+            coveragePipe = new CoveragePipe({
+                apiKey: TESTOMATIO,
+                testomatioUrl: TESTOMATIO_URL,
+                isBatchEnabled: false
+            });
+
+            expect(coveragePipe.isEnabled).to.equal(false);
+        });
+
+        it('in prod version COVERAGE_BY_DEFAULT_GIT_FILE should be all time false', async () => {
+            const branchName = "master";
+            
+            // Coverage pipe preparation
+            process.env.COVERAGE_FILEPATH = TEMP_COVERAGE_FILE;
+            process.env.COVERAGE_BRANCH = branchName;
+    
+            coveragePipe = new CoveragePipe({
+                apiKey: TESTOMATIO,
+                testomatioUrl: TESTOMATIO_URL,
+                isBatchEnabled: false
+            });
+
+            expect(coveragePipe.isDefaultGitChanges).to.equal(false);
+        });
+    });
+});

--- a/tests/unit/pipes/coverage_pipe_test.js
+++ b/tests/unit/pipes/coverage_pipe_test.js
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import ServerMock from 'mock-http-server';
 import fs from 'fs';
 import path from 'path';
-import { execSync } from 'child_process';
 import CoveragePipe from '../../../src/pipe/coverage.js';
 import { config } from '../../adapter/config/index.js';
 import { fileURLToPath } from 'url';
@@ -32,7 +31,8 @@ describe('CoveragePipe: general positive cases.', () => {
         coveragePipe = new CoveragePipe({
             apiKey: TESTOMATIO,
             testomatioUrl: TESTOMATIO_URL,
-            isBatchEnabled: false
+            isBatchEnabled: false,
+            pipeOptions: `file=${TEMP_COVERAGE_FILE}`
         });
 
         server.start(() => {
@@ -67,7 +67,7 @@ describe('CoveragePipe: general positive cases.', () => {
     beforeEach(() => {
         originalEnv = { ...process.env };
         process.env.TESTOMATIO_URL = TESTOMATIO_URL;
-        process.env.COVERAGE_FILEPATH = TEMP_COVERAGE_FILE;
+        // process.env.COVERAGE_FILEPATH = TEMP_COVERAGE_FILE;
         process.env['INPUT_TESTOMATIO-KEY'] = TESTOMATIO;
     });
 

--- a/tests/unit/pipes/coverage_pipe_test.js
+++ b/tests/unit/pipes/coverage_pipe_test.js
@@ -189,32 +189,9 @@ describe('CoveragePipe: general positive cases.', () => {
     });
 });
 
-describe('CoveragePipe general setup cases.', () => {
+describe('CoveragePipe general class cases.', () => {
     let coveragePipe;
     let originalEnv;
-
-    before(done => {
-        // Ensure clean temp directory
-        if (!fs.existsSync(TEMP_COVER_DIR)) {
-            fs.mkdirSync(TEMP_COVER_DIR);
-            console.log(`[mock-tmp-folder]: tmp folder was created - ${TEMP_COVER_DIR}`);
-        }
-
-        done();
-    });
-
-    after(done => {
-        // Cleanup temp directory
-        if (fs.existsSync(TEMP_COVER_DIR)) {
-            fs.readdirSync(TEMP_COVER_DIR).forEach(file => {
-                fs.unlinkSync(path.join(TEMP_COVER_DIR, file));
-            });
-            fs.rmdirSync(TEMP_COVER_DIR);
-            console.log(`[mock-tmp-folder]: tmp folder was removed - ${TEMP_COVER_DIR}`);
-        }
-
-        done();
-    });
 
     beforeEach(() => {
         originalEnv = { ...process.env };
@@ -228,10 +205,6 @@ describe('CoveragePipe general setup cases.', () => {
         delete process.env.COVERAGE_BY_DEFAULT_GIT_FILE;
 
         coveragePipe = undefined;
-
-        fs.readdirSync(TEMP_COVER_DIR).forEach(file => {
-            fs.unlinkSync(path.join(TEMP_COVER_DIR, file));
-        });
     });
 
     describe('Coverage class - diff branch tests', () => {

--- a/tests/unit/pipes/misc_pipe_test.js
+++ b/tests/unit/pipes/misc_pipe_test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { parseFilterParams, updateFilterType, generateFilterRequestParams } from '../../../src/utils/pipe_utils.js';
 
-describe('testing ipe/misc.js functions', () => {
+describe('testing utils/pipe_utils.js functions', () => {
   describe('updateFilterType function', () => {
     it('should return "tag" when input is "tag-name"', () => {
       const result = updateFilterType('tag-name');
@@ -50,7 +50,7 @@ describe('testing ipe/misc.js functions', () => {
     it('should handle unsupported type correctly', () => {
       const input = 'unsupported-type=abc';
       const result = parseFilterParams(input);
-      expect(result).to.deep.equal({ type: undefined, id: 'abc' });
+      expect(result).to.be.undefined;
     });
 
     it('should handle undefined input correctly', () => {

--- a/tests/unit/pipes/testomatio_pipe_test.js
+++ b/tests/unit/pipes/testomatio_pipe_test.js
@@ -260,7 +260,7 @@ describe('TestomatioPipe', () => {
     it('should handle invalid filter format', async () => {
       const result = await testomatioPipe.prepareRun('invalid-filter-format');
 
-      expect(result).to.be.undefined;
+      expect(result).to.deep.equal([]);
     });
 
     it('should verify correct request parameters are sent', async () => {


### PR DESCRIPTION
New Coverage task  start-test run mode (coverage pipe) V3: 
- separate "coverage" pipe with `prepareRun(params)` function (move coverage to pipe);
- combine filter & coverage to one run section (cleanup `cli.js`);
- fix git command to 2 different type:  `git diff master --name-only` or `git diff <branch-name> --name-only` cmd;
- use `minimatch js` lib to parse `.yml` file.

Short Coverage pipe functionality description:
- Retrieved modified files using `git diff --name-only` cmd;
- Validated coverage file  & parsed relevant coverage data;
- Extracted test IDs and generated a full `--grep` command for targeted test runs;
(original ticket - https://github.com/testomatio/playtika-issues/issues/32 )

Example:
- command: `TESTOMATIO_URL=http://xxx TESTOMATIO=tstxxx npx @testomatio/reporter run "npx codeceptjs run" --filter "coverage:file=coverage/coverage.yml, diff=my-branch"`
- `coverage.yml` file example: 
```yml
// coverage.yml
todomvc-tests/helpers/**:
  - "@S171a8408"
  - "@T091ed49e"
todomvc-tests/edit-todos_test.js:
  - "@T091ed49e"
todomvc-tests/pages/**/*.js:
  - "tag:@step-06"
  - "@Safaa0ab4"

```
Future updates:
- create a new test plan at the end??? - **WIP**
- possible duplicates of tests in case if `--grep "(Safaa0ab4|Tc85d62e4)"` and suite includes this test?? - **WIP**
- deeper testing by user??? - **WIP**