### PR TITLE
fix: fix typings when importing package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "engines": {
     "node": ">=18"
   },
-  "typings": "typings/index.d.ts",
+  "main": "lib/reporter.js",
+  "module": "lib/reporter.js",
+  "types": "types/types.d.ts",
   "repository": "git@github.com:testomatio/reporter.git",
   "author": "Michael Bodnarchuk <davert@testomat.io>,Koushik Mohan <koushikmohan1996@gmail.com>",
   "license": "MIT",
@@ -109,7 +111,7 @@
   },
   "exports": {
     ".": {
-      "import": "./src/reporter.js",
+      "import": "./lib/reporter.js",
       "require": "./lib/reporter.js",
       "types": "./types/types.d.ts"
     },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "bin",
     "lib",
     "src",
-    "testcafe"
+    "testcafe",
+    "types"
   ],
   "scripts": {
     "clear-exportdir": "rm -rf export/",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": ">=18"
   },
   "main": "lib/reporter.js",
-  "module": "lib/reporter.js",
+  "module": "src/reporter.js",
   "types": "types/types.d.ts",
   "repository": "git@github.com:testomatio/reporter.git",
   "author": "Michael Bodnarchuk <davert@testomat.io>,Koushik Mohan <koushikmohan1996@gmail.com>",
@@ -111,7 +111,7 @@
   },
   "exports": {
     ".": {
-      "import": "./lib/reporter.js",
+      "import": "./src/reporter.js",
       "require": "./lib/reporter.js",
       "types": "./types/types.d.ts"
     },


### PR DESCRIPTION
It should fix error like
`Cannot find module '@testomatio/reporter' or its corresponding type declarations.ts(2307)`