### PR TITLE
Fix CLI filter flag for Jest and add Cypress grep support

### DIFF
--- a/docs/frameworks.md
+++ b/docs/frameworks.md
@@ -141,6 +141,19 @@ TESTOMATIO={API_KEY} npx cypress run
 
 > 🖼 Screenshots of failed tests and videos will be automatically uploaded as [Artifacts](./artifacts.md)
 
+For test filtering functionality to work properly, install the `@cypress/grep` plugin:
+
+```bash
+npm install --save-dev @cypress/grep
+```
+
+This plugin enables filtering commands that use grep functionality:
+
+```bash
+# Filter tests by pattern
+npx cypress run --env grep="pattern"
+```
+
 > 📑 [Example Project](https://github.com/testomatio/examples/tree/master/cypress) | 🥒 [Cypress + Cucumber Example](https://github.com/testomatio/examples/tree/master/cypress-cucumber)
 
 ### Mocha

--- a/docs/frameworks.md
+++ b/docs/frameworks.md
@@ -147,12 +147,16 @@ For test filtering functionality to work properly, install the `@cypress/grep` p
 npm install --save-dev @cypress/grep
 ```
 
-This plugin enables filtering commands that use grep functionality:
+This plugin enables filtering Cypress tests via the grep environment variable
 
 ```bash
 # Filter tests by pattern
-npx cypress run --env grep="pattern"
+npx cypress run --env '{"grep":"T123","grepFilterSpecs":true,"grepOmitFiltered":true}'
 ```
+
+Note: with @cypress/grep Cypress still loads the whole spec file and shows all tests in the output,
+but tests that do not match grep are marked as pending (effectively skipped).
+Only the matched tests are actually executed and reported
 
 > 📑 [Example Project](https://github.com/testomatio/examples/tree/master/cypress) | 🥒 [Cypress + Cucumber Example](https://github.com/testomatio/examples/tree/master/cypress-cucumber)
 

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -7,7 +7,7 @@ import createDebugMessages from 'debug';
 import TestomatClient from '../client.js';
 import XmlReader from '../xmlReader.js';
 import { APP_PREFIX, STATUS } from '../constants.js';
-import { cleanLatestRunId, getPackageVersion } from '../utils/utils.js';
+import { cleanLatestRunId, getPackageVersion, applyFilter } from '../utils/utils.js';
 import { config } from '../config.js';
 import { readLatestRunId } from '../utils/utils.js';
 import pc from 'picocolors';
@@ -100,7 +100,7 @@ program
       try {
         const tests = await client.prepareRun({ pipe, pipeOptions });
         if (tests && tests.length > 0) {
-          command += ` --grep (${tests.join('|')})`;
+          command = applyFilter(command, tests);
         }
       } catch (err) {
         console.log(APP_PREFIX, err);

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -99,9 +99,7 @@ program
 
       try {
         const tests = await client.prepareRun({ pipe, pipeOptions });
-        if (tests && tests.length > 0) {
-          command = applyFilter(command, tests);
-        }
+        command = applyFilter(command, tests);
       } catch (err) {
         console.log(APP_PREFIX, err);
       }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -615,6 +615,27 @@ function truncate(s, size = 255) {
   return `${str.substring(0, size)}...`;
 }
 
+function applyFilter(command, tests) {
+  if (!tests || !tests.length) return command;
+
+  const lower = (command || '').toLowerCase();
+  const pattern = `(${tests.join('|')})`;
+
+  if (lower.includes('jest')) {
+    return `${command} --testNamePattern "${pattern}"`;
+  }
+
+  if (lower.includes('cypress')) {
+    if (command.includes('--env')) {
+      return `${command},grep="${pattern}",grepFilterSpecs=true`;
+    }
+    return `${command} --env grep="${pattern}",grepFilterSpecs=true`;
+  }
+
+  return `${command} --grep "${pattern}"`;
+}
+
+
 export {
   ansiRegExp,
   truncate,
@@ -640,4 +661,5 @@ export {
   testRunnerHelper,
   transformEnvVarToBoolean,
   validateSuiteId,
+  applyFilter
 };

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -619,24 +619,57 @@ function applyFilter(command, tests) {
   if (!tests || !tests.length) return command;
 
   const lower = (command || '').toLowerCase();
-  const pattern = `(${tests.join('|')})`;
+  const regexPattern = `(${tests.join('|')})`;
 
   if (lower.includes('jest')) {
-    return `${command} --testNamePattern "${pattern}"`;
+    return `${command} --testNamePattern ${regexPattern}`;
   }
 
   if (lower.includes('cypress')) {
+    const grepValue = tests.join(',');
+    const baseEnv = {
+      grep: grepValue,
+      grepFilterSpecs: true,
+      grepOmitFiltered: true,
+    };
+
     if (command.includes('--env')) {
       return command.replace(
-        /--env\s+([^\s]+)/,
-        (match, envVal) => `--env ${envVal},grep="${pattern}",grepFilterSpecs=true`
+        /--env\s+(['"]?)([^\s'"]+)\1/,
+        (match, quote, envVal) => {
+          const existingEnv = {};
+
+          if (envVal.startsWith('{') && envVal.endsWith('}')) {
+            try {
+              Object.assign(existingEnv, JSON.parse(envVal));
+            } catch (e) {
+            }
+          }
+
+          if (!Object.keys(existingEnv).length) {
+            envVal.split(',').forEach((pair) => {
+              const [k, v] = pair.split('=');
+              if (!k) return;
+
+              if (v === 'true') existingEnv[k] = true;
+              else if (v === 'false') existingEnv[k] = false;
+              else existingEnv[k] = v;
+            });
+          }
+
+          const merged = { ...existingEnv, ...baseEnv };
+          const json = JSON.stringify(merged);
+
+          return `--env ${json}`;
+        },
       );
     }
 
-    return `${command} --env grep="${pattern}",grepFilterSpecs=true`;
+    const json = JSON.stringify(baseEnv);
+    return `${command} --env ${json}`;
   }
 
-  return `${command} --grep "${pattern}"`;
+  return `${command} --grep ${regexPattern}`;
 }
 
 export {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -627,14 +627,17 @@ function applyFilter(command, tests) {
 
   if (lower.includes('cypress')) {
     if (command.includes('--env')) {
-      return `${command},grep="${pattern}",grepFilterSpecs=true`;
+      return command.replace(
+        /--env\s+([^\s]+)/,
+        (match, envVal) => `--env ${envVal},grep="${pattern}",grepFilterSpecs=true`
+      );
     }
+
     return `${command} --env grep="${pattern}",grepFilterSpecs=true`;
   }
 
   return `${command} --grep "${pattern}"`;
 }
-
 
 export {
   ansiRegExp,

--- a/tests/unit/util_test.js
+++ b/tests/unit/util_test.js
@@ -32,6 +32,7 @@ import {
   testRunnerHelper,
   transformEnvVarToBoolean,
   validateSuiteId,
+  applyFilter,
 } from '../../src/utils/utils.js';
 
 describe('Utils', () => {
@@ -690,6 +691,64 @@ ${process.cwd()}/tests/unit/data/cli/RunCest.php:24
         expect(transformEnvVarToBoolean([])).to.be.false; // empty array -> "" -> false (empty string after trim)
         expect(transformEnvVarToBoolean([1, 2])).to.be.true; // array -> "1,2" -> true (not recognized, so Boolean("1,2"))
       });
+    });
+  });
+
+  describe('#applyFilter', () => {
+    it('should return original command when tests list is empty or undefined', () => {
+      expect(applyFilter('npx jest', [])).to.eql('npx jest');
+      expect(applyFilter('npx jest', null)).to.eql('npx jest');
+      expect(applyFilter('npx jest', undefined)).to.eql('npx jest');
+    });
+
+    it('should append --testNamePattern for Jest commands', () => {
+      const cmd = 'npx jest';
+      const result = applyFilter(cmd, ['T123', 'T456']);
+      expect(result).to.eql('npx jest --testNamePattern (T123|T456)');
+    });
+
+    it('should detect Jest command case-insensitively', () => {
+      const cmd = 'npx Jest tests/unit';
+      const result = applyFilter(cmd, ['T1']);
+      expect(result).to.eql('npx Jest tests/unit --testNamePattern (T1)');
+    });
+
+    it('should append --grep for non-Jest / non-Cypress commands', () => {
+      const cmd = 'npx playwright test';
+      const result = applyFilter(cmd, ['T1', 'T2']);
+      expect(result).to.eql('npx playwright test --grep (T1|T2)');
+    });
+
+    it('should add --env with grep options for Cypress when no existing --env', () => {
+      const cmd = 'npx cypress run --browser chrome';
+      const result = applyFilter(cmd, ['T0171ba11']);
+      expect(result).to.eql(
+        'npx cypress run --browser chrome --env {"grep":"T0171ba11","grepFilterSpecs":true,"grepOmitFiltered":true}'
+      );
+    });
+
+    it('should extend existing unquoted --env for Cypress', () => {
+      const cmd = 'npx cypress run --env FOO=bar';
+      const result = applyFilter(cmd, ['T1', 'T2']);
+      expect(result).to.eql(
+        'npx cypress run --env {"FOO":"bar","grep":"T1,T2","grepFilterSpecs":true,"grepOmitFiltered":true}'
+      );
+    });
+
+    it('should extend existing quoted --env for Cypress', () => {
+      const cmd = 'npx cypress run --env "FOO=bar,baz=1"';
+      const result = applyFilter(cmd, ['T1', 'T2']);
+      expect(result).to.eql(
+        'npx cypress run --env {"FOO":"bar","baz":"1","grep":"T1,T2","grepFilterSpecs":true,"grepOmitFiltered":true}'
+      );
+    });
+
+    it('should detect Cypress command case-insensitively', () => {
+      const cmd = 'npx Cypress run';
+      const result = applyFilter(cmd, ['T1']);
+      expect(result).to.eql(
+        'npx Cypress run --env {"grep":"T1","grepFilterSpecs":true,"grepOmitFiltered":true}'
+      );
     });
   });
 });


### PR DESCRIPTION
## Problem

`@testomatio/reporter run` always appended `--grep` when building a filtered command, e.g.:

- `--filter "coverage:file=coverage.yml,diff=main"`
- `--filter "testomatio:label=Automatable"`

(https://github.com/testomatio/reporter/issues/643)

This caused a few issues:

1. **Jest**  
   Jest does not support `--grep`, so filtered runs failed with  
   `Unrecognized option "grep"` and any pipes based on filters (coverage, labels, etc.) could not be used.

2. **Cypress**  
   Cypress CLI has no native name-based filter like `--grep`, so filters were silently ignored for Cypress runs – all tests/specs were still executed.

## Solution

- Detect the test framework from the provided command and apply a framework-specific filter:

  - **Jest** – use  
    ```bash
    --testNamePattern "(Txxxx|Tyyyy|Tzzzz)"
    ```  
    instead of `--grep`, so filtered runs work correctly.

  - **Cypress** – for projects using `@cypress/grep`, append  
    ```bash
    --env grep="(Txxxx|Tyyyy|Tzzzz)",grepFilterSpecs=true
    ```  
    so only tests matching the Testomatio IDs are executed.

  - **Other runners** (Mocha, Playwright, CodeceptJS, etc.) – keep using  
    ```bash
    --grep "(Txxxx|Tyyyy|Tzzzz)"
    ```

- If no tests are returned by the API for a given filter, the original command is left unchanged.
