### PR TITLE
fix: pass TESTOMATIO_RUN to child runner process

### DIFF
--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -113,7 +113,7 @@ program
       const testCmds = command.split(' ');
       const cmd = spawn(testCmds[0], testCmds.slice(1), {
         stdio: 'inherit',
-        env: { ...process.env, TESTOMATIO_PROCEED: 'true', runId: client.runId },
+        env: { ...process.env, TESTOMATIO_PROCEED: 'true', runId: client.runId, TESTOMATIO_RUN: client.runId },
       });
 
       cmd.on('close', async code => {


### PR DESCRIPTION
Previously, the `run` command in `cli.js` only passed a custom `runId` env variable to the spawned test runner:

    env: { ...process.env, TESTOMATIO_PROCEED: 'true', runId: client.runId }

Reporter adapters inside the test runner (mocha/jest/etc.) expect `TESTOMATIO_RUN`.
Because this variable was missing, they either created a new run or reused the last stored run id, which led to
empty / duplicate runs when using `@testomatio/reporter run ... --filter ...`.

We now explicitly pass `TESTOMATIO_RUN` alongside `runId`:

    env: {
      ...process.env,
      TESTOMATIO_PROCEED: 'true',
      runId: client.runId,
      TESTOMATIO_RUN: client.runId,
    }
