### PR TITLE
Fix issue #655: Preserve full stacktrace in Jest error reports

### DIFF
--- a/src/adapter/jest.js
+++ b/src/adapter/jest.js
@@ -44,8 +44,7 @@ export class JestReporter {
       let steps;
       const { status, title, duration, failureMessages } = result;
       if (failureMessages[0]) {
-        let errorMessage = failureMessages[0].replace(ansiRegExp(), '');
-        errorMessage = errorMessage.split('\n')[0];
+        const errorMessage = failureMessages[0].replace(ansiRegExp(), '');
         error = new Error(errorMessage);
         steps = failureMessages[0];
       }


### PR DESCRIPTION
Removed truncating error stacktrace to first line.
Now error objects contain complete stack traces with file paths and line numbers.

https://github.com/testomatio/reporter/issues/655