### PR TITLE
Create run from coverage

### DIFF
--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -145,7 +145,7 @@ program
         if (client.pipeStore.runUrl) console.log(APP_PREFIX, `📊 Report URL: ${pc.magenta(client.pipeStore.runUrl)}`);
 
         if (opts.kind !== 'manual') {
-          console.log(APP_PREFIX, `No command passed, so you need to run tests yourself:`)
+          console.log(APP_PREFIX, `No command passed, so you need to run tests yourself:`);
           console.log(APP_PREFIX, `TESTOMATIO_RUN=${runId} <command>`);
         }
       } else {

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -79,22 +79,17 @@ program
   .command('run')
   .alias('test')
   .description('Run tests with the specified command')
-  .argument('<command>', 'Test runner command')
+  .argument('[command]', 'Test runner command')
   .option('--filter <filter>', 'Additional execution filter')
   .option('--filter-list <filter>', 'Get a list of all tests by filter before running')
   .option('--kind <type>', 'Specify run type: automated, manual, or mixed')
   .action(async (command, opts) => {
     const apiKey = process.env['INPUT_TESTOMATIO-KEY'] || config.TESTOMATIO;
     const title = process.env.TESTOMATIO_TITLE;
-
-    if (!command || !command.split) {
-      console.log(APP_PREFIX, `No command provided. Use -c option to launch a test runner.`);
-      return process.exit(255);
-    }
-
     const client = new TestomatClient({ apiKey, title });
 
     if (opts.filter || opts.filterList) {
+      console.log(APP_PREFIX,'Filtering tests...');
       // Example of use: npx @testomatio/reporter run "npx jest" --filter "testomatio:tag-name=frontend"
       // Example of use: npx @testomatio/reporter run "npx jest" --filter "coverage:file=coverage.yml"
       // Example of use: npx @testomatio/reporter run "npx jest" --filter-list "coverage:file=coverage.yml"
@@ -102,6 +97,9 @@ program
       const pipeOptions = optsArray.join(':');
 
       const prepareRunParams = { pipe, pipeOptions };
+      if (opts.filterList) {
+        client.pipeStore.filterList = true;
+      }
 
       try {
         const tests = await client.prepareRun(prepareRunParams);
@@ -118,16 +116,43 @@ program
 
         if(opts.filterList) {
           console.log(APP_PREFIX, pc.blue(`Matched test/suite IDs: ${tests.join(', ')}`));
-          console.log(APP_PREFIX, pc.green(`Full Running Command: ${filteredCommand}`));
+          if (command) console.log(APP_PREFIX, pc.green(`Full Running Command: ${filteredCommand}`));
           return;
         }
-        
-        command = filteredCommand;
-      } 
+
+        if (command && command.split) {
+          command = filteredCommand;
+        }
+      }
       catch (err) {
         console.log(APP_PREFIX, err.message || err);
         return;
       }
+    }
+
+    if (!command || !command.split) {
+      const createRunParams = {};
+      if (title) {
+        createRunParams.title = title;
+      }
+      if (opts.kind) {
+        createRunParams.kind = opts.kind;
+      }
+
+      if (apiKey) {
+        await client.createRun(createRunParams);
+        const runId = process.env.TESTOMATIO_RUN || process.env.runId;
+        if (client.pipeStore.runUrl) console.log(APP_PREFIX, `📊 Report URL: ${pc.magenta(client.pipeStore.runUrl)}`);
+
+        if (opts.kind !== 'manual') {
+          console.log(APP_PREFIX, `No command passed, so you need to run tests yourself:`)
+          console.log(APP_PREFIX, `TESTOMATIO_RUN=${runId} <command>`);
+        }
+      } else {
+        console.log(APP_PREFIX, '⚠️  No API key provided. Cannot create run without TESTOMATIO key.');
+        process.exit(1);
+      }
+      return process.exit(0);
     }
 
     console.log(APP_PREFIX, `🚀 Running`, pc.green(command));

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -130,6 +130,7 @@ program
       }
     }
 
+    // just create a run (wich tests which match filters) without executing tests
     if (!command || !command.split) {
       const createRunParams = {};
       if (title) {

--- a/src/pipe/coverage.js
+++ b/src/pipe/coverage.js
@@ -469,7 +469,7 @@ class CoveragePipe { // or Changes for the future???
           const affectedItems = [];
           if (suitesCount > 0) affectedItems.push(`**${suitesCount} suites**`);
           if (testsCount > 0) affectedItems.push(`**${testsCount} individual tests**`);
-          description += `May affect ${affectedItems.join(' and ')} which are recommended to be checked for regression.\n\n`;
+          description += `May affect ${affectedItems.join(' and ')} which are recommended to be tested for regression.\n\n`; // eslint-disable-line
         }
         description += 'Updated source files:\n';
         if (updatedFiles.length) {

--- a/src/pipe/coverage.js
+++ b/src/pipe/coverage.js
@@ -54,7 +54,7 @@ class CoveragePipe { // or Changes for the future???
 
         this.branch = options?.diff || process.env.COVERAGE_BRANCH || this.#GIT.default_branch;
         this.isBranchDefault = !options.diff && !process.env.COVERAGE_BRANCH;
-        
+
         if (this.isBranchDefault) {
             console.log(
                 APP_PREFIX,
@@ -98,7 +98,7 @@ class CoveragePipe { // or Changes for the future???
             }
         });
 
-        // In case if we have all needed data 
+        // In case if we have all needed data
         this.isEnabled = true;
 
         debug('Coverage Pipe initialized', {
@@ -108,7 +108,7 @@ class CoveragePipe { // or Changes for the future???
 
         this.parsedCoverage = {};
         this.changedFiles = [];
-        this.matchedLines = new Set();        
+        this.matchedLines = new Set();
         this.tests = new Set();
         this.suiteIds = new Set();
         this.tagLabels = new Set();
@@ -118,12 +118,15 @@ class CoveragePipe { // or Changes for the future???
         debug(`Coverage Pipe: is Enabled = ${this.isEnabled}`);
     }
 
-    async prepareRun(opts) {       
+    async prepareRun(opts) {
         // Reset internal mutable state for isolation
         this.tests.clear();
         this.suiteIds.clear();
         this.tagLabels.clear();
         this.results = [];
+        if (this.store) {
+            this.store.coverageConfiguration = undefined;
+        }
 
         if (!this.isEnabled) return [];
 
@@ -132,6 +135,9 @@ class CoveragePipe { // or Changes for the future???
 
         // Step 2: Extract all available tests and compare with coverage file
         const lines = await this.extractRelevantTestsFromChanges();
+        if (this.store?.filterList && lines.size > 0) {
+            console.log(APP_PREFIX, `Matched files: ${[...lines].join(', ')}`);
+        }
 
         if (lines.size === 0) {
             console.log(APP_PREFIX, 'ℹ️  No matching entries in coverage file for provided Git changes.');
@@ -148,22 +154,33 @@ class CoveragePipe { // or Changes for the future???
                 if (!tests) return [];
 
                 console.log(
-                    APP_PREFIX, 
+                    APP_PREFIX,
                     `✅ We found ${tests.length === 1 ? 'one entry' : `${tests.length} (test/suite) entries`}` +
                     ' in Testomat.io service side.'
                 );
-                
+
                 tests.forEach(testId => this.tests.add(testId));
-            }  
+            }
         }
 
-        if (this.tests.size === 0) {
-            console.log(APP_PREFIX, 'ℹ️  No tests found for execution based on Git changes.');            
+        if (this.tests.size === 0 && this.suiteIds.size === 0) {
+            console.log(APP_PREFIX, 'ℹ️  No tests found for execution based on Git changes.');
             return [];
         }
 
-        this.results = [...this.tests];
-        
+        this.results = [...this.tests, ...this.suiteIds];
+        if (this.store) {
+            this.store.coverageConfiguration = {
+                tests: [...this.tests],
+                suites: [...this.suiteIds],
+            };
+            this.store.coverageDescription = this.#buildRunDescription({
+                matchedLines: lines,
+                testsCount: this.tests.size,
+                suitesCount: this.suiteIds.size,
+            });
+        }
+
         return this.results;
     }
 
@@ -214,18 +231,18 @@ class CoveragePipe { // or Changes for the future???
 
             if (!Array.isArray(resp.data?.tests) && resp.data?.tests?.length === 0) {
                 console.log(APP_PREFIX, `🔍 No test by ${type}=${id} were found on the Testomat.io server side!`);
-                
+
                 return undefined;
             }
 
             return resp.data.tests;
-        } 
+        }
         catch (err) {
             console.error(
                 APP_PREFIX,
                 `🚩 Error getting available tests from the Testomat.io by "test_grep" option: ${err}`
             );
-            
+
             return undefined;
         }
     }
@@ -243,48 +260,48 @@ class CoveragePipe { // or Changes for the future???
                 encoding: 'utf-8',
                 stdio: ['pipe', 'pipe', 'ignore']
             });
-    
+
             return result
                 .split('\n')
                 .map(f => f.trim())
                 .filter(Boolean);
-        } 
+        }
         catch (err) {
             const errorMessage = err.message || '';
             // Git edge: Not a git repository or other error
             if (errorMessage.includes('Not a git repository')) {
                 console.error(APP_PREFIX, '❌ Error: This folder is not a Git repository.');
-            } 
+            }
             else {
                 throw new Error(`❌ Git command failed ("${cmd}"):\n`, errorMessage);
             }
-    
+
             return [];
         }
     }
 
     /**
-     * Builds a Git command string to list file changes between the current state 
+     * Builds a Git command string to list file changes between the current state
      * and a specified Git branch using `git diff --name-only`.
-     * 
+     *
      * Private pipe function
      * @throws {Error} Throws an error if `this.branch` is not defined.
      * @returns {string} A Git command string, e.g., 'git diff <branch> --name-only'.
      */
     #buildGitCommand() {
         if (!this.branch) throw new Error(`❌ Invalid changes option for setted branch!`);
-        
-        return `git diff ${this.branch} --name-only`; // Example: 'git diff <master> --name-only' 
+
+        return `git diff ${this.branch} --name-only`; // Example: 'git diff <master> --name-only'
     }
 
     /**
-     * Retrieves the list of files changed in the current Git working directory 
+     * Retrieves the list of files changed in the current Git working directory
      * compared to a specified branch.
      *
-     * This method builds a Git diff command and attempts to retrieve the changed 
+     * This method builds a Git diff command and attempts to retrieve the changed
      * files using that command. It logs helpful information and errors during the process.
      *
-     * If no changed files are found, or an error occurs at any stage, the method logs 
+     * If no changed files are found, or an error occurs at any stage, the method logs
      * the issue and returns `undefined`.
      *
      * @returns {this | undefined} Returns the current instance (`this`) if changed files are found;
@@ -295,12 +312,12 @@ class CoveragePipe { // or Changes for the future???
 
         try {
             cmd = this.#buildGitCommand();
-        } 
+        }
         catch (err) {
             console.error(APP_PREFIX, err.message);
             return undefined;
         }
-        
+
         console.error(APP_PREFIX, `ℹ️  We will use '${cmd}' Git command.`);
 
         try {
@@ -325,9 +342,9 @@ class CoveragePipe { // or Changes for the future???
             console.error(APP_PREFIX, err.message);
             console.error(APP_PREFIX, "🔍 Pls, check this Git command manually to understand the original problem.");
             return undefined;
-        }        
+        }
 
-        console.log(APP_PREFIX, `📑  GIT changed files:\n  - ${this.changedFiles.join('\n  - ')}`);        
+        console.log(APP_PREFIX, `📑  GIT changed files:\n  - ${this.changedFiles.join('\n  - ')}`);
         return this;
     }
 
@@ -412,7 +429,7 @@ class CoveragePipe { // or Changes for the future???
             for (const [pattern, ids] of Object.entries(this.parsedCoverage)) {
               if (minimatch(changedFile, pattern)) {
                 this.matchedLines.add(changedFile);
-      
+
                 ids.forEach(id => {
                     // Example: "@Tt74099t1"
                     if (id.startsWith('@T')) {
@@ -420,7 +437,7 @@ class CoveragePipe { // or Changes for the future???
                     }
                     // Example: "@Sd74099c1"
                     else if (id.startsWith('@S')) {
-                        this.tests.add(id.slice(1));
+                        this.suiteIds.add(id.slice(1));
                     }
                     // Example: "tag:@TestSmoke"
                     else if (id.startsWith('tag')) {
@@ -434,6 +451,47 @@ class CoveragePipe { // or Changes for the future???
         debug(`Matched lines: ${this.matchedLines}`);
 
         return this.matchedLines;
+    }
+
+    #buildRunDescription({ matchedLines, testsCount, suitesCount }) {
+        const sourceBranch =
+            process.env.GITHUB_HEAD_REF ||
+            process.env.GITHUB_REF_NAME ||
+            process.env.CI_COMMIT_REF_NAME ||
+            this.#getCurrentGitBranch() ||
+            'current branch';
+        const targetBranch = this.branch || 'target branch';
+        const coverageFile = this.coverageFilePath ? path.basename(this.coverageFilePath) : 'coverage.yml';
+        const updatedFiles = matchedLines && matchedLines.size > 0 ? [...matchedLines] : this.changedFiles;
+
+        let description = `Changes to **${updatedFiles.length}** files in ${sourceBranch} to ${targetBranch}.\n\n`;
+        if (suitesCount > 0 || testsCount > 0) {
+          const affectedItems = [];
+          if (suitesCount > 0) affectedItems.push(`**${suitesCount} suites**`);
+          if (testsCount > 0) affectedItems.push(`**${testsCount} individual tests**`);
+          description += `May affect ${affectedItems.join(' and ')} which are recommended to be checked for regression.\n\n`;
+        }
+        description += 'Updated source files:\n';
+        if (updatedFiles.length) {
+            description += updatedFiles.map(file => `* \`${file}\``).join('\n');
+            description += '\n\n';
+        } else {
+            description += '* No matched files found\n\n';
+        }
+        description += `Mapping source files to tests set via \`${coverageFile}\` file.`;
+        return description;
+    }
+
+    #getCurrentGitBranch() {
+        try {
+            const branch = execSync('git rev-parse --abbrev-ref HEAD', {
+                encoding: 'utf-8',
+                stdio: ['pipe', 'pipe', 'ignore'],
+            }).trim();
+            return branch || undefined;
+        } catch (err) {
+            return undefined;
+        }
     }
 }
 

--- a/src/pipe/github.js
+++ b/src/pipe/github.js
@@ -142,6 +142,20 @@ class GitHubPipe {
       });
 
     let body = summary;
+    const coverageConfiguration = this.store?.coverageConfiguration;
+    const isManualRun = this.store?.runKind === 'manual';
+    if (isManualRun && coverageConfiguration) {
+      const testsCount = coverageConfiguration.tests?.length || 0;
+      const suitesCount = coverageConfiguration.suites?.length || 0;
+      body += '\n\n<details>\n<summary><h3>🧭 Coverage Scope</h3></summary>\n\n';
+      if (!testsCount && !suitesCount) {
+        body += '- No tests were affected, run disabled\n';
+      } else {
+        body += `- Suites: ${suitesCount}\n`;
+        body += `- Tests: ${testsCount}\n`;
+      }
+      body += '\n</details>';
+    }
 
     if (failures.length) {
       body += `\n<details>\n<summary><h3>🟥 Failures (${failures.length})</h4></summary>\n\n${failures.join('\n')}\n`;

--- a/src/pipe/testomatio.js
+++ b/src/pipe/testomatio.js
@@ -3,11 +3,11 @@ import pc from 'picocolors';
 import { Gaxios } from 'gaxios';
 import JsonCycle from 'json-cycle';
 import { APP_PREFIX, STATUS, AXIOS_TIMEOUT, REPORTER_REQUEST_RETRIES } from '../constants.js';
-import { isValidUrl, 
-  foundedTestLog, 
-  readLatestRunId, 
-  transformEnvVarToBoolean, 
-  getGitCommitSha 
+import { isValidUrl,
+  foundedTestLog,
+  readLatestRunId,
+  transformEnvVarToBoolean,
+  getGitCommitSha
 } from '../utils/utils.js';
 import { parseFilterParams, generateFilterRequestParams, setS3Credentials } from '../utils/pipe_utils.js';
 import { config } from '../config.js';
@@ -198,6 +198,9 @@ class TestomatioPipe {
     if (!this.isEnabled) return;
     if (this.batch.isEnabled && this.isEnabled)
       this.batch.intervalFunction = setInterval(this.#batchUpload, this.batch.intervalTime);
+    if (this.store) {
+      this.store.runKind = params.kind;
+    }
 
     let buildUrl = process.env.BUILD_URL || process.env.CI_JOB_URL || process.env.CIRCLE_BUILD_URL;
 
@@ -219,6 +222,16 @@ class TestomatioPipe {
 
     const accessEvent = process.env.TESTOMATIO_PUBLISH ? 'publish' : null;
 
+    const coverageConfiguration = this.store?.coverageConfiguration;
+    let description = null;
+    let configuration = null;
+    if (coverageConfiguration && (coverageConfiguration.tests?.length || coverageConfiguration.suites?.length)) {
+      description = this.store?.coverageDescription || null;
+      configuration = {
+        tests: coverageConfiguration.tests?.map(id => id.replace(/^T/, '')) || [],
+        suites: coverageConfiguration.suites?.map(id => id.replace(/^S/, '')) || [],
+      };
+    }
     const runParams = Object.fromEntries(
       Object.entries({
         ci_build_url: buildUrl,
@@ -232,6 +245,8 @@ class TestomatioPipe {
         shared_run: this.sharedRun,
         shared_run_timeout: this.sharedRunTimeout,
         kind: params.kind,
+        configuration,
+        description,
       }).filter(([, value]) => !!value),
     );
     debug(' >>>>>> Run params', JSON.stringify(runParams, null, 2));


### PR DESCRIPTION
When we don't want to launch tests right now but we want to create a run in Testomat.io with corresponding tests listed
This is important when we want to launch manual tests based on report provided from coverage pipe

Ability to create new manual or end2end runs from coverage reports:

Manual run 

```
TESTOMATIO=tstmt_... npx @testomatio/reporter run --kind manual --filter "coverage:file=coverage.manual.yml,diff=stable"
```

Automated run

```
TESTOMATIO=tstmt_... npx @testomatio/reporter run --filter "coverage:file=coverage.manual.yml,diff=stable"
```

See also: https://github.com/testomatio/coverage-agent