### PR TITLE
Fix #7228: Show report URL for existing runs

### DIFF
--- a/src/pipe/testomatio.js
+++ b/src/pipe/testomatio.js
@@ -247,7 +247,8 @@ class TestomatioPipe {
       });
       if (resp.data.artifacts) setS3Credentials(resp.data.artifacts);
       if (resp.data.url) {
-        this.runUrl = `${this.url}/${resp.data.url.split('/').splice(3).join('/')}`;
+        const respUrl = new URL(resp.data.url);
+        this.runUrl = `${this.url}${respUrl.pathname}`;
         this.runPublicUrl = resp.data.public_url;
         this.store.runUrl = this.runUrl;
         this.store.runPublicUrl = this.runPublicUrl;

--- a/src/pipe/testomatio.js
+++ b/src/pipe/testomatio.js
@@ -246,6 +246,14 @@ class TestomatioPipe {
         responseType: 'json',
       });
       if (resp.data.artifacts) setS3Credentials(resp.data.artifacts);
+      if (resp.data.url) {
+        this.runUrl = `${this.url}/${resp.data.url.split('/').splice(3).join('/')}`;
+        this.runPublicUrl = resp.data.public_url;
+        this.store.runUrl = this.runUrl;
+        this.store.runPublicUrl = this.runPublicUrl;
+        console.log(APP_PREFIX, '📊 Using existing run. Report ID:', this.runId);
+        console.log(APP_PREFIX, '📊 Report URL:', pc.magenta(this.runUrl));
+      }
       return;
     }
 


### PR DESCRIPTION
Extract URL and public_url from the PUT response when updating an existing run, store them, and display a message to the user. This makes the behavior consistent with creating a new run.