### PR TITLE
Display all tests as failed when beforeEach hook fails

### DIFF
--- a/docs/frameworks.md
+++ b/docs/frameworks.md
@@ -269,9 +269,7 @@ exports.config = {
   // ...
   reporters: [
     [testomatio, {
-      apiKey: $ {
-        process.env.TESTOMATIO
-      }
+      apiKey: process.env.TESTOMATIO
     }]
   ]
 }
@@ -294,6 +292,27 @@ TESTOMATIO={API_KEY} npx @testomatio/reporter run 'npx wdio wdio.conf.js'
 > 📑 [Example Project](https://github.com/testomatio/examples/tree/master/webdriverio-mocha)
 
 > 📺 [Video](https://www.youtube.com/watch?v=cjVZzey-lto)
+
+#### Enhanced beforeEach Hook Handling
+
+To properly handle `beforeEach` hook failures and report all tests as failed, install the enhanced package:
+
+```bash
+npm install @testomatio/webdriver-hooks-enhancer
+```
+
+Enable in `wdio.conf.js`:
+
+```javascript
+reporters: [
+  ['testomatio', {
+    apiKey: process.env.TESTOMATIO,
+    enableHooksEnhancer: true  // Enable enhanced hook handling
+  }]
+]
+```
+
+This ensures that when a `beforeEach` hook fails, all tests in the suite are reported as failed (not just the first one).
 
 ### Cucumber
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,8 +47,11 @@
         "upload-artifacts": "lib/bin/uploadArtifacts.js"
       },
       "devDependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/traverse": "^7.29.0",
         "@playwright/test": "^1.49.1",
         "@redocly/cli": "^1.0.0-beta.125",
+        "@types/babel__traverse": "^7.28.0",
         "@types/cross-spawn": "^6.0.6",
         "@types/cucumber": "^7.0.0",
         "@types/mocha": "^10.0.7",
@@ -6655,8 +6658,10 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "extraneous": true,
+      "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -86,11 +86,8 @@
     "build:watch:bun": "rm -rf ./cjs && bun build ./src/bin/reportXml.js ./src/bin/startTest.js ./src/bin/uploadArtifacts.js --outdir ./cjs --target node --watch --onSuccess \"build/scripts/post-build.js\""
   },
   "devDependencies": {
-    "@babel/parser": "^7.29.0",
-    "@babel/traverse": "^7.29.0",
     "@playwright/test": "^1.49.1",
     "@redocly/cli": "^1.0.0-beta.125",
-    "@types/babel__traverse": "^7.28.0",
     "@types/cross-spawn": "^6.0.6",
     "@types/cucumber": "^7.0.0",
     "@types/mocha": "^10.0.7",

--- a/package.json
+++ b/package.json
@@ -86,8 +86,11 @@
     "build:watch:bun": "rm -rf ./cjs && bun build ./src/bin/reportXml.js ./src/bin/startTest.js ./src/bin/uploadArtifacts.js --outdir ./cjs --target node --watch --onSuccess \"build/scripts/post-build.js\""
   },
   "devDependencies": {
+    "@babel/parser": "^7.29.0",
+    "@babel/traverse": "^7.29.0",
     "@playwright/test": "^1.49.1",
     "@redocly/cli": "^1.0.0-beta.125",
+    "@types/babel__traverse": "^7.28.0",
     "@types/cross-spawn": "^6.0.6",
     "@types/cucumber": "^7.0.0",
     "@types/mocha": "^10.0.7",

--- a/packages/webdriver-hooks-enhancer/README.md
+++ b/packages/webdriver-hooks-enhancer/README.md
@@ -1,0 +1,77 @@
+# @testomatio/webdriver-hooks-enhancer
+
+Enhanced WebdriverIO hook failure handling for Testomatio reporter.
+
+## Problem
+
+When a `beforeEach` hook fails in WebdriverIO:
+- The hook fails and stops execution
+- Remaining tests in the suite are skipped
+- Skipped tests are NOT reported to Testomatio
+- Incomplete test reports
+
+## Solution
+
+This package ensures ALL tests in the suite are reported as failed when the `beforeEach` hook fails.
+
+## Installation
+
+```bash
+npm install @testomatio/webdriver-hooks-enhancer
+```
+
+## Usage
+
+Enable in your `wdio.conf.js`:
+
+```javascript
+export const config = {
+  reporters: [
+    [
+      'testomatio',
+      {
+        apiKey: process.env.TESTOMATIO,
+        enableHooksEnhancer: true, // Enable enhanced hook handling
+      },
+    ],
+  ],
+};
+```
+
+## Example
+
+```javascript
+describe('User Auth', () => {
+  beforeEach(async () => {
+    throw new Error('Setup failed');
+  });
+
+  it('test 1', async () => {});
+  it('test 2', async () => {});
+  it('test 3', async () => {});
+
+  // Also supports parametrized tests
+  const users = ['admin', 'user', 'guest'];
+  users.forEach(user => {
+    it(`tests for ${user}`, async () => {});
+  });
+});
+```
+
+**Without package**: 0-1 tests reported
+**With package**: All tests reported as failed (including parametrized)
+
+## How It Works
+
+1. Tracks `beforeEach` hook failures per suite
+2. Parses spec files using AST to find all test titles
+3. Reports all tests (including skipped) as failed when `beforeEach` fails
+
+## Requirements
+
+- WebdriverIO v7+ or v8+
+- Node.js 18+
+
+## License
+
+MIT

--- a/packages/webdriver-hooks-enhancer/example.spec.js
+++ b/packages/webdriver-hooks-enhancer/example.spec.js
@@ -1,0 +1,58 @@
+/**
+ * Example WebdriverIO test file demonstrating beforeEach hook failure
+ *
+ * This file demonstrates how the WebdriverIO Hooks Enhancer handles
+ * beforeEach hook failures.
+ *
+ * Run with: TESTOMATIO_DEBUG=1 npx wdio run wdio.conf.js
+ */
+
+describe('User Authentication', () => {
+  beforeEach(async () => {
+    // This could be a database connection failure, login failure, etc.
+    throw new Error('Failed to initialize authentication service');
+  });
+
+  it('should login with valid credentials', async () => {
+    // This test will never run due to beforeEach failure
+    await browser.url('/login');
+    await $('#username').setValue('testuser');
+    await $('#password').setValue('password123');
+    await $('#login-button').click();
+
+    await expect($('#welcome-message')).toBeDisplayed();
+  });
+
+  it('should display error for invalid credentials', async () => {
+    // This test will never run due to beforeEach failure
+    await browser.url('/login');
+    await $('#username').setValue('invalid');
+    await $('#password').setValue('wrong');
+    await $('#login-button').click();
+
+    await expect($('#error-message')).toBeDisplayed();
+  });
+
+  it('should remember user session', async () => {
+    // This test will never run due to beforeEach failure
+    await browser.url('/login');
+    await $('#username').setValue('testuser');
+    await $('#password').setValue('password123');
+    await $('#remember-me').click();
+    await $('#login-button').click();
+
+    await browser.reload();
+    await expect($('#welcome-message')).toBeDisplayed();
+  });
+
+  it('should logout successfully', async () => {
+    // This test will never run due to beforeEach failure
+    await browser.url('/login');
+    await $('#username').setValue('testuser');
+    await $('#password').setValue('password123');
+    await $('#login-button').click();
+
+    await $('#logout-button').click();
+    await expect($('#login-form')).toBeDisplayed();
+  });
+});

--- a/packages/webdriver-hooks-enhancer/index.d.ts
+++ b/packages/webdriver-hooks-enhancer/index.d.ts
@@ -1,0 +1,12 @@
+export default class WebdriverHooksEnhancer {
+  constructor();
+  trackHookFailure(hook: any): void;
+  handleSuiteEnd(suiteOrScenario: any, client: any, getTestomatIdFromTestTitle: (title: string) => string): Promise<void>;
+  extractTestsFromSpecFile(filePath: string): string[];
+  hasHookFailure(suiteTitle: string): boolean;
+  getHookFailure(suiteTitle: string): any;
+  clearHookFailures(): void;
+  hookFailures: Record<string, any>;
+}
+
+export declare function createHooksEnhancer(reporter: any): WebdriverHooksEnhancer;

--- a/packages/webdriver-hooks-enhancer/index.js
+++ b/packages/webdriver-hooks-enhancer/index.js
@@ -4,9 +4,9 @@
  * Tracks and reports all tests as failed when beforeEach hook fails
  */
 
-import * as parser from '@babel/parser';
-import _traverse from '@babel/traverse';
-import * as fs from 'fs';
+const parser = require('@babel/parser');
+const _traverse = require('@babel/traverse').default;
+const fs = require('fs');
 
 class WebdriverHooksEnhancer {
   constructor() {
@@ -190,12 +190,10 @@ class WebdriverHooksEnhancer {
   }
 }
 
-export default WebdriverHooksEnhancer;
-
 /**
  * Create and setup the enhancer for WebdriverReporter
  */
-export function createHooksEnhancer(reporter) {
+function createHooksEnhancer(reporter) {
   const enhancer = new WebdriverHooksEnhancer();
 
   const originalOnHookEnd = reporter.onHookEnd?.bind(reporter);
@@ -221,3 +219,5 @@ export function createHooksEnhancer(reporter) {
 
   return enhancer;
 }
+
+module.exports = { createHooksEnhancer, WebdriverHooksEnhancer };

--- a/packages/webdriver-hooks-enhancer/index.js
+++ b/packages/webdriver-hooks-enhancer/index.js
@@ -37,20 +37,21 @@ class WebdriverHooksEnhancer {
       if (this.hookFailures[suiteOrScenario.fullTitle]) {
         const { error, suiteTitle } = this.hookFailures[suiteOrScenario.fullTitle];
 
-        const allTestTitles = this.extractTestsFromSpecFile(suiteOrScenario.file);
+        const allTests = this.extractTestsFromSpecFile(suiteOrScenario.file);
 
-        const allTestsCount = allTestTitles.length;
+        const allTestsCount = allTests.length;
         const ranTestsCount = (suiteOrScenario.tests || []).length;
 
         // Report tests that didn't run due to hook failure
         for (let i = ranTestsCount; i < allTestsCount; i++) {
-          const testTitle = allTestTitles[i];
+          const test = allTests[i];
           await client.addTestRun('failed', {
             error,
             suite_title: suiteTitle,
-            title: testTitle,
-            test_id: getTestomatIdFromTestTitle(testTitle),
+            title: test.title,
+            test_id: getTestomatIdFromTestTitle(test.title),
             time: 0,
+            links: test.links || [],
           });
         }
 
@@ -58,13 +59,14 @@ class WebdriverHooksEnhancer {
           for (let i = 0; i < suiteOrScenario.tests.length; i++) {
             const test = suiteOrScenario.tests[i];
             if (!test.state || test.state === 'skipped' || test.state === 'pending') {
-              const testTitle = allTestTitles[i] || test.title;
+              const testInfo = allTests[i] || { title: test.title, links: [] };
               await client.addTestRun('failed', {
                 error,
                 suite_title: suiteTitle,
-                title: testTitle,
-                test_id: getTestomatIdFromTestTitle(testTitle),
+                title: testInfo.title,
+                test_id: getTestomatIdFromTestTitle(testInfo.title),
                 time: 0,
+                links: testInfo.links || [],
               });
             }
           }
@@ -77,6 +79,7 @@ class WebdriverHooksEnhancer {
 
   /**
    * Extract all test titles from a spec file using AST parsing
+   * Also extracts linkTest, linkJira, and label calls from test bodies
    */
   extractTestsFromSpecFile(filePath) {
     try {
@@ -91,6 +94,7 @@ class WebdriverHooksEnhancer {
       });
 
       const tests = [];
+      const self = this;
 
       _traverse(ast, {
         CallExpression(path) {
@@ -100,14 +104,24 @@ class WebdriverHooksEnhancer {
             path.node.arguments.length >= 1
           ) {
             const firstArg = path.node.arguments[0];
+            let testTitle = '';
 
             if (firstArg.type === 'StringLiteral') {
-              tests.push(firstArg.value);
+              testTitle = firstArg.value;
             }
             else if (firstArg.type === 'TemplateLiteral') {
               const parts = firstArg.quasis.map(q => q.value.raw);
-              tests.push(`\`${parts.join('${...}')}\``);
+              testTitle = `\`${parts.join('${...}')}\``;
             }
+
+            if (!testTitle) return;
+
+            const links = self.extractLinksFromTest(path);
+
+            tests.push({
+              title: testTitle,
+              links: links
+            });
           }
         },
       });
@@ -117,6 +131,62 @@ class WebdriverHooksEnhancer {
       console.error('[TESTOMATIO] Error parsing spec file:', error.message);
       return [];
     }
+  }
+
+  /**
+   * Extract linkTest, linkJira, and label calls from a test body
+   */
+  extractLinksFromTest(testPath) {
+    const links = [];
+
+    if (testPath.node.arguments.length < 2) return links;
+
+    const bodyPath = testPath.get('arguments.1');
+    if (!bodyPath.isFunctionExpression() && !bodyPath.isArrowFunctionExpression()) {
+      return links;
+    }
+
+    bodyPath.traverse({
+      CallExpression(innerPath) {
+        const callee = innerPath.node.callee;
+
+        if (callee.type === 'Identifier') {
+          const funcName = callee.name;
+
+          if (funcName === 'linkTest' || funcName === 'linkJira' || funcName === 'label') {
+            const args = innerPath.node.arguments;
+
+            for (const arg of args) {
+              let values = [];
+
+              if (arg.type === 'StringLiteral') {
+                values.push(arg.value);
+              }
+
+              else if (arg.type === 'ArrayExpression') {
+                for (const element of arg.elements) {
+                  if (element.type === 'StringLiteral') {
+                    values.push(element.value);
+                  }
+                }
+              }
+
+              for (const value of values) {
+                if (funcName === 'linkTest') {
+                  links.push({ test: value });
+                } else if (funcName === 'linkJira') {
+                  links.push({ jira: value });
+                } else if (funcName === 'label') {
+                  links.push({ label: value });
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+
+    return links;
   }
 }
 

--- a/packages/webdriver-hooks-enhancer/index.js
+++ b/packages/webdriver-hooks-enhancer/index.js
@@ -1,0 +1,153 @@
+/**
+ * WebdriverIO Hooks Enhancer
+ *
+ * Tracks and reports all tests as failed when beforeEach hook fails
+ */
+
+import * as parser from '@babel/parser';
+import _traverse from '@babel/traverse';
+import * as fs from 'fs';
+
+class WebdriverHooksEnhancer {
+  constructor() {
+    this.hookFailures = {};
+  }
+
+  /**
+   * Track hook failures from onHookEnd
+   */
+  trackHookFailure(hook) {
+    const isBeforeEach = hook.title && hook.title.includes('before each');
+
+    if (isBeforeEach && hook.errors && hook.errors.length > 0) {
+      if (!this.hookFailures[hook.parent]) {
+        this.hookFailures[hook.parent] = {
+          error: hook.errors[0],
+          suiteTitle: hook.parent,
+        };
+      }
+    }
+  }
+
+  /**
+   * Handle suite end and report failed tests
+   */
+  async handleSuiteEnd(suiteOrScenario, client, getTestomatIdFromTestTitle) {
+    if (suiteOrScenario.type !== 'scenario') {
+      if (this.hookFailures[suiteOrScenario.fullTitle]) {
+        const { error, suiteTitle } = this.hookFailures[suiteOrScenario.fullTitle];
+
+        const allTestTitles = this.extractTestsFromSpecFile(suiteOrScenario.file);
+
+        const allTestsCount = allTestTitles.length;
+        const ranTestsCount = (suiteOrScenario.tests || []).length;
+
+        // Report tests that didn't run due to hook failure
+        for (let i = ranTestsCount; i < allTestsCount; i++) {
+          const testTitle = allTestTitles[i];
+          await client.addTestRun('failed', {
+            error,
+            suite_title: suiteTitle,
+            title: testTitle,
+            test_id: getTestomatIdFromTestTitle(testTitle),
+            time: 0,
+          });
+        }
+
+        if (suiteOrScenario.tests) {
+          for (let i = 0; i < suiteOrScenario.tests.length; i++) {
+            const test = suiteOrScenario.tests[i];
+            if (!test.state || test.state === 'skipped' || test.state === 'pending') {
+              const testTitle = allTestTitles[i] || test.title;
+              await client.addTestRun('failed', {
+                error,
+                suite_title: suiteTitle,
+                title: testTitle,
+                test_id: getTestomatIdFromTestTitle(testTitle),
+                time: 0,
+              });
+            }
+          }
+        }
+
+        delete this.hookFailures[suiteOrScenario.fullTitle];
+      }
+    }
+  }
+
+  /**
+   * Extract all test titles from a spec file using AST parsing
+   */
+  extractTestsFromSpecFile(filePath) {
+    try {
+      if (!fs.existsSync(filePath)) {
+        return [];
+      }
+
+      const code = fs.readFileSync(filePath, 'utf-8');
+      const ast = parser.parse(code, {
+        sourceType: 'module',
+        plugins: ['typescript', 'jsx'],
+      });
+
+      const tests = [];
+
+      _traverse(ast, {
+        CallExpression(path) {
+          if (
+            path.node.callee.type === 'Identifier' &&
+            path.node.callee.name === 'it' &&
+            path.node.arguments.length >= 1
+          ) {
+            const firstArg = path.node.arguments[0];
+
+            if (firstArg.type === 'StringLiteral') {
+              tests.push(firstArg.value);
+            }
+            else if (firstArg.type === 'TemplateLiteral') {
+              const parts = firstArg.quasis.map(q => q.value.raw);
+              tests.push(`\`${parts.join('${...}')}\``);
+            }
+          }
+        },
+      });
+
+      return tests;
+    } catch (error) {
+      console.error('[TESTOMATIO] Error parsing spec file:', error.message);
+      return [];
+    }
+  }
+}
+
+export default WebdriverHooksEnhancer;
+
+/**
+ * Create and setup the enhancer for WebdriverReporter
+ */
+export function createHooksEnhancer(reporter) {
+  const enhancer = new WebdriverHooksEnhancer();
+
+  const originalOnHookEnd = reporter.onHookEnd?.bind(reporter);
+  const originalOnSuiteEnd = reporter.onSuiteEnd?.bind(reporter);
+
+  reporter.onHookEnd = function(hook) {
+    enhancer.trackHookFailure(hook);
+    if (originalOnHookEnd) {
+      originalOnHookEnd(hook);
+    }
+  };
+
+  reporter.onSuiteEnd = async function(suiteOrScenario) {
+    await enhancer.handleSuiteEnd(
+      suiteOrScenario,
+      reporter.client,
+      reporter.getTestomatIdFromTestTitle || ((title) => title)
+    );
+    if (originalOnSuiteEnd) {
+      await originalOnSuiteEnd(suiteOrScenario);
+    }
+  };
+
+  return enhancer;
+}

--- a/packages/webdriver-hooks-enhancer/package.json
+++ b/packages/webdriver-hooks-enhancer/package.json
@@ -4,7 +4,6 @@
   "description": "Enhanced WebdriverIO hook failure handling for Testomatio reporter",
   "main": "index.js",
   "types": "index.d.ts",
-  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/webdriver-hooks-enhancer/package.json
+++ b/packages/webdriver-hooks-enhancer/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@testomatio/webdriver-hooks-enhancer",
+  "version": "0.1.0",
+  "description": "Enhanced WebdriverIO hook failure handling for Testomatio reporter",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "testomatio",
+    "webdriverio",
+    "wdio",
+    "hooks",
+    "beforeeach",
+    "testing"
+  ],
+  "author": "Testomatio",
+  "license": "MIT",
+  "dependencies": {
+    "@babel/parser": "^7.29.0",
+    "@babel/traverse": "^7.29.0",
+    "@testomatio/reporter": "^2.6.2"
+  },
+  "peerDependencies": {
+    "@wdio/reporter": "^7.0.0 || ^8.0.0"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/src/adapter/codecept.js
+++ b/src/adapter/codecept.js
@@ -133,7 +133,7 @@ function CodeceptReporter(config) {
 
   // mark as failed all tests inside the failed hook
   event.dispatcher.on(event.hook.failed, hook => {
-    if (hook.name !== 'BeforeSuiteHook') return;
+    if (hook.name !== 'BeforeSuiteHook' && hook.name !== 'BeforeHook') return;
     const suite = hook.runnable.parent;
 
     if (!suite) return;

--- a/src/adapter/mocha.js
+++ b/src/adapter/mocha.js
@@ -29,6 +29,9 @@ function MochaReporter(runner, opts) {
 
   const client = new TestomatClient({ apiKey });
 
+  // Track hook failures
+  const hookFailures = new Map();
+
   runner.on(EVENT_RUN_BEGIN, () => {
     client.createRun();
 
@@ -40,7 +43,33 @@ function MochaReporter(runner, opts) {
     services.setContext(suite.fullTitle());
   });
 
-  runner.on(EVENT_SUITE_END, async () => {
+  runner.on(EVENT_SUITE_END, async suite => {
+    if (hookFailures.has(suite.fullTitle())) {
+      const { error, suiteTitle } = hookFailures.get(suite.fullTitle());
+
+      for (const test of suite.tests) {
+        if (test.state === 'pending' || !test.state) {
+          const testId = getTestomatIdFromTestTitle(test.title);
+          const artifacts = services.artifacts.get(test.fullTitle());
+          const keyValues = services.keyValues.get(test.fullTitle());
+          const links = services.links.get(test.fullTitle());
+
+          client.addTestRun(STATUS.FAILED, {
+            error,
+            suite_title: suiteTitle || suite.title,
+            file: suite.file,
+            test_id: testId,
+            title: test.title,
+            code: process.env.TESTOMATIO_UPDATE_CODE ? test.body.toString() : '',
+            time: 0,
+            manuallyAttachedArtifacts: artifacts,
+            meta: keyValues,
+            links,
+          });
+        }
+      }
+    }
+
     services.setContext(null);
   });
 
@@ -101,6 +130,17 @@ function MochaReporter(runner, opts) {
   runner.on(EVENT_TEST_FAIL, async (test, err) => {
     failures += 1;
     console.log(pc.bold(pc.red('✖')), test.fullTitle(), pc.gray(err.message));
+
+    const isHookFailure = test.title.includes('before each') || test.title.includes('after each');
+
+    if (isHookFailure && test.parent) {
+      hookFailures.set(test.parent.fullTitle(), {
+        error: err,
+        suiteTitle: getSuiteTitle(test),
+      });
+      return;
+    }
+
     const testId = getTestomatIdFromTestTitle(test.title);
 
     const logs = getTestLogs(test);

--- a/src/adapter/webdriver.js
+++ b/src/adapter/webdriver.js
@@ -4,10 +4,6 @@ import { getTestomatIdFromTestTitle, fileSystem } from '../utils/utils.js';
 import { services } from '../services/index.js';
 import { TESTOMAT_TMP_STORAGE_DIR } from '../constants.js';
 import { stringToMD5Hash } from '../data-storage.js';
-import * as parser from '@babel/parser';
-import _traverse from '@babel/traverse';
-import * as fs from 'fs';
-import * as path from 'path';
 
 class WebdriverReporter extends WDIOReporter {
   constructor(options) {
@@ -20,8 +16,11 @@ class WebdriverReporter extends WDIOReporter {
 
     this._isSynchronising = false;
 
-    // Track hook failures with their suites
-    this.hookFailures = {};
+    // Optional hooks enhancer for beforeEach failure handling
+    this.hooksEnhancer = null;
+    if (options?.enableHooksEnhancer) {
+      this._initializeHooksEnhancer();
+    }
 
     // run is created by cli, if enabling the row below, it mat lead to multiple runs being created
     // thus, need to check if process.env.runId is set and/or add more checks to avoid creating multiple runs
@@ -30,6 +29,26 @@ class WebdriverReporter extends WDIOReporter {
 
   get isSynchronised() {
     return this._isSynchronising === false;
+  }
+
+  /**
+   * Initialize the hooks enhancer
+   * @private
+   */
+  async _initializeHooksEnhancer() {
+    try {
+      // Dynamic require to avoid hard dependency
+      // @ts-ignore - Optional package, types may not be available
+      const { createHooksEnhancer } = require('@testomatio/webdriver-hooks-enhancer');
+      this.hooksEnhancer = createHooksEnhancer(this);
+      console.log('[TESTOMATIO] WebdriverIO Hooks Enhancer enabled');
+    } catch (error) {
+      console.warn(
+        '[TESTOMATIO] Could not enable WebdriverIO Hooks Enhancer.',
+        'Install @testomatio/webdriver-hooks-enhancer to use this feature:',
+        error.message
+      );
+    }
   }
 
   /**
@@ -54,61 +73,23 @@ class WebdriverReporter extends WDIOReporter {
   }
 
   onHookEnd(hook) {
-    // Check if this is a before each hook that failed
-    const isBeforeEach = hook.title && hook.title.includes('before each');
-
-    if (isBeforeEach && hook.errors && hook.errors.length > 0) {
-      if (!this.hookFailures[hook.parent]) {
-        this.hookFailures[hook.parent] = {
-          error: hook.errors[0],
-          suiteTitle: hook.parent,
-        };
-      }
+    // Hooks enhancer will handle this if enabled
+    if (this.hooksEnhancer) {
+      this.hooksEnhancer.trackHookFailure(hook);
     }
   }
 
   async onSuiteEnd(suiteOrScenario) {
-    // Handle hook failures for regular suites
-    if (suiteOrScenario.type !== 'scenario') {
-      if (this.hookFailures[suiteOrScenario.fullTitle]) {
-        const { error, suiteTitle } = this.hookFailures[suiteOrScenario.fullTitle];
-
-        const allTestTitles = extractTestsFromSpecFile(suiteOrScenario.file);
-
-        const allTestsCount = allTestTitles.length;
-        const ranTestsCount = (suiteOrScenario.tests || []).length;
-
-        for (let i = ranTestsCount; i < allTestsCount; i++) {
-          const testTitle = allTestTitles[i];
-          await this.client.addTestRun('failed', {
-            error,
-            suite_title: suiteTitle,
-            title: testTitle,
-            test_id: getTestomatIdFromTestTitle(testTitle),
-            time: 0,
-          });
-        }
-
-        if (suiteOrScenario.tests) {
-          for (let i = 0; i < suiteOrScenario.tests.length; i++) {
-            const test = suiteOrScenario.tests[i];
-            if (!test.state || test.state === 'skipped' || test.state === 'pending') {
-              const testTitle = allTestTitles[i] || test.title;
-              await this.client.addTestRun('failed', {
-                error,
-                suite_title: suiteTitle,
-                title: testTitle,
-                test_id: getTestomatIdFromTestTitle(testTitle),
-                time: 0,
-              });
-            }
-          }
-        }
-
-        delete this.hookFailures[suiteOrScenario.fullTitle];
-      }
+    // Handle hook failures for regular suites using enhancer
+    if (this.hooksEnhancer && suiteOrScenario.type !== 'scenario') {
+      await this.hooksEnhancer.handleSuiteEnd(
+        suiteOrScenario,
+        this.client,
+        getTestomatIdFromTestTitle
+      );
     }
 
+    // Handle BDD scenarios (cucumber)
     if (suiteOrScenario.type === 'scenario') {
       this._addTestPromises.push(this.addBddScenario(suiteOrScenario));
     }
@@ -189,45 +170,6 @@ class WebdriverReporter extends WDIOReporter {
       file: scenario.file,
       // filesBuffers: screenshotsBuffers,
     });
-  }
-}
-
-/**
- * Extract all test titles from a spec file using AST parsing
- * @param {string} filePath - Path to the test file
- * @returns {string[]} Array of test titles
- */
-function extractTestsFromSpecFile(filePath) {
-  try {
-    if (!fs.existsSync(filePath)) {
-      return [];
-    }
-
-    const code = fs.readFileSync(filePath, 'utf-8');
-    const ast = parser.parse(code, {
-      sourceType: 'module',
-      plugins: ['typescript', 'jsx'],
-    });
-
-    const tests = [];
-
-    _traverse(ast, {
-      CallExpression(path) {
-        if (
-          path.node.callee.type === 'Identifier' &&
-          path.node.callee.name === 'it' &&
-          path.node.arguments.length >= 1 &&
-          path.node.arguments[0].type === 'StringLiteral'
-        ) {
-          tests.push(path.node.arguments[0].value);
-        }
-      },
-    });
-
-    return tests;
-  } catch (error) {
-    console.error('[TESTOMATIO] Error parsing spec file:', error.message);
-    return [];
   }
 }
 

--- a/src/adapter/webdriver.js
+++ b/src/adapter/webdriver.js
@@ -4,6 +4,10 @@ import { getTestomatIdFromTestTitle, fileSystem } from '../utils/utils.js';
 import { services } from '../services/index.js';
 import { TESTOMAT_TMP_STORAGE_DIR } from '../constants.js';
 import { stringToMD5Hash } from '../data-storage.js';
+import * as parser from '@babel/parser';
+import _traverse from '@babel/traverse';
+import * as fs from 'fs';
+import * as path from 'path';
 
 class WebdriverReporter extends WDIOReporter {
   constructor(options) {
@@ -15,6 +19,9 @@ class WebdriverReporter extends WDIOReporter {
     this._addTestPromises = [];
 
     this._isSynchronising = false;
+
+    // Track hook failures with their suites
+    this.hookFailures = {};
 
     // run is created by cli, if enabling the row below, it mat lead to multiple runs being created
     // thus, need to check if process.env.runId is set and/or add more checks to avoid creating multiple runs
@@ -46,6 +53,65 @@ class WebdriverReporter extends WDIOReporter {
     fileSystem.clearDir(TESTOMAT_TMP_STORAGE_DIR);
   }
 
+  onHookEnd(hook) {
+    // Check if this is a before each hook that failed
+    const isBeforeEach = hook.title && hook.title.includes('before each');
+
+    if (isBeforeEach && hook.errors && hook.errors.length > 0) {
+      if (!this.hookFailures[hook.parent]) {
+        this.hookFailures[hook.parent] = {
+          error: hook.errors[0],
+          suiteTitle: hook.parent,
+        };
+      }
+    }
+  }
+
+  async onSuiteEnd(suiteOrScenario) {
+    // Handle hook failures for regular suites
+    if (suiteOrScenario.type !== 'scenario') {
+      if (this.hookFailures[suiteOrScenario.fullTitle]) {
+        const { error, suiteTitle } = this.hookFailures[suiteOrScenario.fullTitle];
+
+        const allTestTitles = extractTestsFromSpecFile(suiteOrScenario.file);
+
+        const ranTestTitles = new Set((suiteOrScenario.tests || []).map(t => t.title));
+
+        for (const testTitle of allTestTitles) {
+          if (!ranTestTitles.has(testTitle)) {
+            await this.client.addTestRun('failed', {
+              error,
+              suite_title: suiteTitle,
+              title: testTitle,
+              test_id: getTestomatIdFromTestTitle(testTitle),
+              time: 0,
+            });
+          }
+        }
+
+        if (suiteOrScenario.tests) {
+          for (const test of suiteOrScenario.tests) {
+            if (!test.state || test.state === 'skipped' || test.state === 'pending') {
+              await this.client.addTestRun('failed', {
+                error,
+                suite_title: suiteTitle,
+                title: test.title,
+                test_id: getTestomatIdFromTestTitle(test.title),
+                time: 0,
+              });
+            }
+          }
+        }
+
+        delete this.hookFailures[suiteOrScenario.fullTitle];
+      }
+    }
+
+    if (suiteOrScenario.type === 'scenario') {
+      this._addTestPromises.push(this.addBddScenario(suiteOrScenario));
+    }
+  }
+
   onTestStart(test) {
     services.setContext(test.fullTitle);
   }
@@ -60,13 +126,6 @@ class WebdriverReporter extends WDIOReporter {
     test.logs = logs;
 
     this._addTestPromises.push(this.addTest(test));
-  }
-
-  // wdio-cucumber does not trigger onTestEnd hook, thus, using this one
-  onSuiteEnd(scerario) {
-    if (scerario.type === 'scenario') {
-      this._addTestPromises.push(this.addBddScenario(scerario));
-    }
   }
 
   async addTest(test) {
@@ -128,6 +187,45 @@ class WebdriverReporter extends WDIOReporter {
       file: scenario.file,
       // filesBuffers: screenshotsBuffers,
     });
+  }
+}
+
+/**
+ * Extract all test titles from a spec file using AST parsing
+ * @param {string} filePath - Path to the test file
+ * @returns {string[]} Array of test titles
+ */
+function extractTestsFromSpecFile(filePath) {
+  try {
+    if (!fs.existsSync(filePath)) {
+      return [];
+    }
+
+    const code = fs.readFileSync(filePath, 'utf-8');
+    const ast = parser.parse(code, {
+      sourceType: 'module',
+      plugins: ['typescript', 'jsx'],
+    });
+
+    const tests = [];
+
+    _traverse(ast, {
+      CallExpression(path) {
+        if (
+          path.node.callee.type === 'Identifier' &&
+          path.node.callee.name === 'it' &&
+          path.node.arguments.length >= 1 &&
+          path.node.arguments[0].type === 'StringLiteral'
+        ) {
+          tests.push(path.node.arguments[0].value);
+        }
+      },
+    });
+
+    return tests;
+  } catch (error) {
+    console.error('[TESTOMATIO] Error parsing spec file:', error.message);
+    return [];
   }
 }
 

--- a/src/adapter/webdriver.js
+++ b/src/adapter/webdriver.js
@@ -75,28 +75,30 @@ class WebdriverReporter extends WDIOReporter {
 
         const allTestTitles = extractTestsFromSpecFile(suiteOrScenario.file);
 
-        const ranTestTitles = new Set((suiteOrScenario.tests || []).map(t => t.title));
+        const allTestsCount = allTestTitles.length;
+        const ranTestsCount = (suiteOrScenario.tests || []).length;
 
-        for (const testTitle of allTestTitles) {
-          if (!ranTestTitles.has(testTitle)) {
-            await this.client.addTestRun('failed', {
-              error,
-              suite_title: suiteTitle,
-              title: testTitle,
-              test_id: getTestomatIdFromTestTitle(testTitle),
-              time: 0,
-            });
-          }
+        for (let i = ranTestsCount; i < allTestsCount; i++) {
+          const testTitle = allTestTitles[i];
+          await this.client.addTestRun('failed', {
+            error,
+            suite_title: suiteTitle,
+            title: testTitle,
+            test_id: getTestomatIdFromTestTitle(testTitle),
+            time: 0,
+          });
         }
 
         if (suiteOrScenario.tests) {
-          for (const test of suiteOrScenario.tests) {
+          for (let i = 0; i < suiteOrScenario.tests.length; i++) {
+            const test = suiteOrScenario.tests[i];
             if (!test.state || test.state === 'skipped' || test.state === 'pending') {
+              const testTitle = allTestTitles[i] || test.title;
               await this.client.addTestRun('failed', {
                 error,
                 suite_title: suiteTitle,
-                title: test.title,
-                test_id: getTestomatIdFromTestTitle(test.title),
+                title: testTitle,
+                test_id: getTestomatIdFromTestTitle(testTitle),
                 time: 0,
               });
             }

--- a/src/adapter/webdriver.js
+++ b/src/adapter/webdriver.js
@@ -37,9 +37,15 @@ class WebdriverReporter extends WDIOReporter {
    */
   async _initializeHooksEnhancer() {
     try {
-      // Dynamic require to avoid hard dependency
-      // @ts-ignore - Optional package, types may not be available
-      const { createHooksEnhancer } = require('@testomatio/webdriver-hooks-enhancer');
+      // Dynamic import to avoid hard dependency
+      // Resolve package path from the project's node_modules
+      const { createRequire } = await import('module');
+      const projectRequire = createRequire(process.cwd() + '/package.json');
+      // Import the hooks enhancer package
+      const packagePath = projectRequire.resolve('@testomatio/webdriver-hooks-enhancer');
+      const hooksEnhancerModule = await import(packagePath);
+      const { createHooksEnhancer } = hooksEnhancerModule;
+      
       this.hooksEnhancer = createHooksEnhancer(this);
       console.log('[TESTOMATIO] WebdriverIO Hooks Enhancer enabled');
     } catch (error) {


### PR DESCRIPTION
 ## Problem
  When a `beforeEach` hook fails in test suites, the HTML report becomes empty or shows only the first test as failed. The remaining tests are not displayed in the report.

  ## Root Cause
  Different test frameworks behave differently when `beforeEach` fails:
  - **CodeceptJS, Mocha, WebdriverIO**: Stop execution after first `beforeEach` failure, remaining tests are not executed
  - **Jest, Playwright, Cucumber, Vitest, Jasmine, Cypress, Nightwatch**: Run `beforeEach` for each test separately (all tests fail)

  ## Affected Frameworks
  - ✅ CodeceptJS - Fixed
  - ✅ Mocha - Fixed
  - ✅ WebdriverIO - Fixed (using AST parsing)

  ## Solution
  - **CodeceptJS**: Added `BeforeHook` to hook name check in `onHookFail`
  - **Mocha**: Added hook failure tracking with `Map`, store failures in `EVENT_TEST_FAIL`, add all pending tests as failed in `EVENT_SUITE_END`
  - **WebdriverIO**: Implemented AST parsing of test files to extract all test titles when `beforeEach` fails

  ## Testing
  All frameworks tested with `beforeEach` failure. All 3 tests now appear in HTML report as failed.