### PR TITLE
fix: rename bin entry to valid name for Yarn 4 (Berry) compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "vitest": "^1.6.0"
   },
   "bin": {
-    "testomatio/reporter": "./src/bin/cli.js",
+    "testomatio-reporter": "./src/bin/cli.js",
     "report-xml": "./src/bin/reportXml.js",
     "start-test-run": "./src/bin/startTest.js",
     "upload-artifacts": "./src/bin/uploadArtifacts.js"


### PR DESCRIPTION
## Summary

Renames the `bin` entry in `package.json` from `"testomatio/reporter"` to `"testomatio-reporter"`.

The forward slash in `"testomatio/reporter"` is rejected by Yarn 4 (Berry) during the link step:

```
Error: Invalid ident (testomatio/reporter)
```

**This is a follow-up to PR #617 / issue #446**, which removed the `@` prefix but left the `/`, which is still invalid for Yarn Berry's identifier parser.

## Why this breaks

- The npm registry metadata normalizes the bin name (so `npm view @testomatio/reporter bin` shows `"reporter"`), which is why npm-based installs work fine
- However, Yarn 4 reads the raw `package.json` from inside the tarball, where the original `"testomatio/reporter"` key is preserved
- Yarn 4's `Sa()` ident parser then rejects the slash

## What this changes

One line in `package.json`:

```diff
 "bin": {
-    "testomatio/reporter": "./src/bin/cli.js",
+    "testomatio-reporter": "./src/bin/cli.js",
```

The dash-separated name `testomatio-reporter` is a valid POSIX command name and preserves the namespacing intent.

## Testing

- Verified locally: `yarn add @testomatio/reporter` in a Yarn 4.12.0 project now succeeds with this fix applied as a local patch

Fixes #716

Made with [Cursor](https://cursor.com)