### PR TITLE
fix: ESM bin entries and startTest.js __dirname resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,10 +110,10 @@
     "vitest": "^1.6.0"
   },
   "bin": {
-    "testomatio/reporter": "./lib/bin/cli.js",
-    "report-xml": "./lib/bin/reportXml.js",
-    "start-test-run": "./lib/bin/startTest.js",
-    "upload-artifacts": "./lib/bin/uploadArtifacts.js"
+    "testomatio/reporter": "./src/bin/cli.js",
+    "report-xml": "./src/bin/reportXml.js",
+    "start-test-run": "./src/bin/startTest.js",
+    "upload-artifacts": "./src/bin/uploadArtifacts.js"
   },
   "exports": {
     ".": {

--- a/src/bin/startTest.js
+++ b/src/bin/startTest.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 import { spawn } from 'node:child_process';
 import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { getPackageVersion } from '../utils/utils.js';
 import pc from 'picocolors';
 
-// Define __dirname - this will be replaced by build script with actual __dirname for CommonJS
-const __dirname = typeof globalThis.__dirname !== 'undefined' ? globalThis.__dirname : '.';
+const __dirname = dirname(fileURLToPath(import.meta.url));
 const cliPath = join(__dirname, 'cli.js');
 
 const version = getPackageVersion();

--- a/src/bin/startTest.js
+++ b/src/bin/startTest.js
@@ -5,7 +5,8 @@ import { fileURLToPath } from 'node:url';
 import { getPackageVersion } from '../utils/utils.js';
 import pc from 'picocolors';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
+// @ts-ignore
+const __dirname = typeof global.__dirname !== 'undefined' ? global.__dirname : dirname(fileURLToPath(import.meta.url));
 const cliPath = join(__dirname, 'cli.js');
 
 const version = getPackageVersion();


### PR DESCRIPTION
## Summary
- **bin entries** in `package.json` now point to `src/bin/` (ESM) instead of `lib/bin/` (CJS), fixing `ERR_REQUIRE_ESM` when `@octokit/rest` is loaded on Node <22.12
- **startTest.js** uses `import.meta.url` instead of broken `globalThis.__dirname || '.'` fallback, which resolved to the user's cwd in ESM causing `Cannot find module cli.js`

## Test plan
- [ ] `npx @testomatio/reporter xml` works on Node 18/20/22/24
- [ ] `npx start-test-run -c "..."` resolves `cli.js` correctly
- [ ] GitHub pipe posts PR comment without `ERR_REQUIRE_ESM`

🤖 Generated with [Claude Code](https://claude.com/claude-code)