### PR TITLE
Preserve explicit create flag in Testomatio pipe for report-xml flow 

### DIFF
--- a/src/pipe/testomatio.js
+++ b/src/pipe/testomatio.js
@@ -117,7 +117,7 @@ class TestomatioPipe {
    */
   #formatData(data) {
     data.api_key = this.apiKey;
-    data.create = this.createNewTests;
+    if (data.create === undefined) data.create = this.createNewTests;
 
     // add test ID + run ID
     if (data.rid) data.rid = `${this.runId}-${data.rid}`;

--- a/tests/unit/pipes/testomatio_pipe_test.js
+++ b/tests/unit/pipes/testomatio_pipe_test.js
@@ -831,5 +831,43 @@ describe('TestomatioPipe', () => {
         expect(testData.stack).to.equal('Error stack trace');
       });
     });
+
+    describe('create flag handling', () => {
+      it('should preserve explicit create flag from test data', () => {
+        delete process.env.TESTOMATIO_CREATE;
+
+        const testData = {
+          title: 'Test with explicit create',
+          status: 'passed',
+          create: true,
+          steps: [],
+          stack: '',
+        };
+
+        pipe.addTest(testData);
+        expect(testData.create).to.equal(true);
+      });
+
+      it('should use pipe default create flag when create is not provided', () => {
+        process.env.TESTOMATIO_CREATE = '1';
+
+        const createPipe = new TestomatioPipe({
+          apiKey: TESTOMATIO,
+          testomatioUrl: TESTOMATIO_URL,
+          isBatchEnabled: false,
+        });
+        createPipe.runId = 'test-run-id';
+
+        const testData = {
+          title: 'Test without create',
+          status: 'passed',
+          steps: [],
+          stack: '',
+        };
+
+        createPipe.addTest(testData);
+        expect(testData.create).to.equal(true);
+      });
+    });
   });
 });


### PR DESCRIPTION
### Root cause:   
                                                                                                                                                                                                                                                                                                                                                                         
  - In TestomatioPipe.#formatData, we always overwrote data.create with this.createNewTests.                                                                                                      
  - After XML upload flow changes (chunking/per-test addTest path), this override started affecting XML payloads more often.                                                                      
  - XML parser already sets create: true for parsed tests, but pipe-level overwrite forced it to false unless TESTOMATIO_CREATE=1 was explicitly set.                                             
  - As a result, existing matching behavior in detached flows degraded, especially for tests relying on suite/title-based matching.                                                               
                                                                                                                                                                                                  
### Why it worked before:                                                                                                                                                                           
                                                                                                                                                                                                  
  - Before the XML flow change, uploads were finalized via a different path (finishRun with full tests payload), where XML-provided create semantics were effectively preserved.                  
  - After switching to per-test uploads, pipe formatting became the decisive step, exposing the unconditional overwrite.                                                                          
                                                                                                                                                                                                  
 ### What changed:                                                                                                                                                                                   
                                                                                                                                                                                                  
  - Updated src/pipe/testomatio.js:                                                                                                                                                               
      - from: data.create = this.createNewTests                                                                                                                                                   
      - to: if (data.create === undefined) data.create = this.createNewTests                                                                                                                      
  - This preserves explicit create from XML test data while still applying pipe default when create is not provided