### PR TITLE
Remove step duplication from stack field

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -257,7 +257,7 @@ class Client {
       message = error?.message;
     }
 
-    let fullLogs = formatLogs({ error: errorFormatted, steps, logs: testData.logs });
+    let fullLogs = formatLogs({ error: errorFormatted, logs: testData.logs });
 
     if (stackArtifactsEnabled && fullLogs?.trim()?.length > 0) {
       uploadedFiles.push(

--- a/src/utils/log-formatter.js
+++ b/src/utils/log-formatter.js
@@ -11,7 +11,7 @@ const stripColors = stripVTControlCharacters || (str => str?.replace(/\x1b\[[0-9
  * Returns the formatted stack including the stack trace, steps, and logs.
  * @param {Object} params - Parameters for formatting logs
  * @param {string} params.error - Error message
- * @param {Array|any} params.steps - Test steps (array or other types)
+ * @param {Array|any} [params.steps] - Test steps (array or other types)
  * @param {string} params.logs - Test logs
  * @returns {string}
  */

--- a/tests/adapter/codecept_steps_sections.test.js
+++ b/tests/adapter/codecept_steps_sections.test.js
@@ -51,12 +51,12 @@ describe('CodeceptJS Steps and Sections Reporting', function () {
       expect(dataProcessingSection.steps).to.be.an('array');
       expect(resultVerificationSection.steps).to.be.an('array');
 
-      // Check stack field formatting
+      // Check stack field does not contain steps (steps are in data.steps only)
       const stack = testEntry.testId.stack;
-      expect(stack).to.include('################[ Logs ]################');
-      expect(stack).to.include('User Authentication');
-      expect(stack).to.include('Data Processing');
-      expect(stack).to.include('Result Verification');
+      expect(stack).to.not.include('################[ Steps ]################');
+      expect(stack).to.not.include('User Authentication');
+      expect(stack).to.not.include('Data Processing');
+      expect(stack).to.not.include('Result Verification');
     });
 
     it('should preserve Section formatting in failed test steps', async () => {
@@ -84,12 +84,12 @@ describe('CodeceptJS Steps and Sections Reporting', function () {
       expect(successfulSection).to.exist;
       expect(failureSection).to.exist;
 
-      // Check stack field includes both steps and failure info
+      // Check stack field includes failure info but not steps
       const stack = testEntry.testId.stack;
-      expect(stack).to.include('################[ Logs ]################');
       expect(stack).to.include('################[ Failure ]################');
-      expect(stack).to.include('Successful Operations');
-      expect(stack).to.include('Operations with Failure');
+      expect(stack).to.not.include('################[ Steps ]################');
+      expect(stack).to.not.include('Successful Operations');
+      expect(stack).to.not.include('Operations with Failure');
       expect(stack).to.include('AssertionError');
     });
 

--- a/tests/unit/client_stack_artifacts_test.js
+++ b/tests/unit/client_stack_artifacts_test.js
@@ -145,7 +145,7 @@ describe('Client Stack Artifacts', () => {
       // Check that the uploaded file contains the logs
       const uploadedBuffer = uploadCalls[0].buffer;
       const uploadedContent = uploadedBuffer.toString('utf8');
-      expect(uploadedContent).to.include('Step 1');
+      expect(uploadedContent).not.to.include('Step 1');
       expect(uploadedContent).to.include('Small logs');
     });
 


### PR DESCRIPTION
## Summary

- Remove steps from `formatLogs()` call in `client.js` so `data.stack` contains only error stacktrace and logs, not duplicated step text
- Steps are already sent as structured objects via `data.steps` — having them also embedded in `data.stack` was redundant
- All pipes handle this correctly: HTML pipe prefers `test.steps` array, GitHub/GitLab/Bitbucket/CSV pipes get cleaner output

## Test plan

- [x] Updated assertion in `client_stack_artifacts_test.js` to verify steps are no longer in log artifacts
- [x] All 378 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)