### PR TITLE
Fix XML reader handling for nested testsuite structures

### DIFF
--- a/src/xmlReader.js
+++ b/src/xmlReader.js
@@ -651,34 +651,26 @@ class XmlReader {
 
 export default XmlReader;
 
-function toArray(value) {
-  if (!value) return [];
-  return Array.isArray(value) ? value : [value];
-}
+function reduceTestCases(prev, item) {
+  let testCases = item.testcase;
+  if (!testCases) testCases = item['test-case'];
+  if (!Array.isArray(testCases)) {
+    testCases = [testCases];
+  }
 
-function collectProperties(item) {
-  if (!item?.properties) return [];
-  return Array.isArray(item.properties.property)
-    ? item.properties.property.filter(Boolean)
-    : [item.properties.property].filter(Boolean);
-}
+  // suite inside test case
+  const testCase = item['test-suite']?.['test-case'];
+  if (testCase) {
+    const nestedCases = Array.isArray(testCase) ? testCase : [testCase];
+    testCases.push(...nestedCases);
+  }
 
-function extractTestsFromSuite(item, parentContext = {}) {
-  const testCases = toArray(item.testcase || item['test-case']);
   const suiteOutput = item['system-out'] || item.output || item.log || '';
   const suiteErr = item['system-err'] || item.output || item.log || '';
-  const context = {
-    file: item.filepath || item.file || item.fullname || item.package || parentContext.file || '',
-    output: [parentContext.output, suiteOutput].filter(Boolean).join('\n\n'),
-    err: [parentContext.err, suiteErr].filter(Boolean).join('\n\n'),
-    properties: [...(parentContext.properties || []), ...collectProperties(item)],
-  };
-  const tests = [];
-
   testCases
     .filter(t => !!t)
     .forEach(testCaseItem => {
-      const file = testCaseItem.file || context.file;
+      const file = testCaseItem.file || item.filepath || item.fullname || item.package || '';
 
       let stack = '';
       let message = '';
@@ -696,10 +688,7 @@ function extractTestsFromSuite(item, parentContext = {}) {
       const preferClassname = reduceOptions.preferClassname || isParametrized;
 
       // SpecFlow config
-      let { title, tags, testId } = fetchProperties(
-        isParametrized ? item : testCaseItem,
-        isParametrized ? context.properties : undefined,
-      );
+      let { title, tags, testId } = fetchProperties(isParametrized ? item : testCaseItem);
       let example = null;
       const suiteTitle = preferClassname ? testCaseItem.classname : item.name || testCaseItem.classname;
 
@@ -717,9 +706,9 @@ function extractTestsFromSuite(item, parentContext = {}) {
         title = title.replace(/\(.*?\)/, '').trim();
       }
 
-      stack = `${testCaseItem['system-out'] || testCaseItem.output || testCaseItem.log || ''}\n\n${stack}\n\n${
-        context.output
-      }\n\n${context.err}`.trim();
+      stack = `${
+        testCaseItem['system-out'] || testCaseItem.output || testCaseItem.log || ''
+      }\n\n${stack}\n\n${suiteOutput}\n\n${suiteErr}`.trim();
 
       if (!testId) testId = fetchIdFromOutput(stack);
 
@@ -755,7 +744,7 @@ function extractTestsFromSuite(item, parentContext = {}) {
       const stackFiles = fetchFilesFromStackTrace(stack);
       files = [...new Set([...files, ...stackFiles])]; // Remove duplicates
 
-      tests.push({
+      prev.push({
         rid,
         file,
         stack,
@@ -775,26 +764,37 @@ function extractTestsFromSuite(item, parentContext = {}) {
         retry: false,
       });
     });
-
-  const nestedSuites = [...toArray(item.testsuite), ...toArray(item['test-suite'])];
-  nestedSuites.forEach(nestedSuite => {
-    tests.push(...extractTestsFromSuite(nestedSuite, context));
-  });
-
-  return tests;
+  return prev;
 }
 
 function processTestSuite(testsuite) {
   if (!testsuite) return [];
-  return toArray(testsuite).flatMap(suite => extractTestsFromSuite(suite));
+  if (testsuite.testsuite && !testsuite.testcase) return processTestSuite(testsuite.testsuite);
+  if (testsuite['test-suite'] && !testsuite['test-case']) return processTestSuite(testsuite['test-suite']);
+
+  let suites = testsuite;
+  if (!Array.isArray(testsuite)) suites = [testsuite];
+
+  const subSuites = suites.filter(
+    s => (s['test-suite'] || s.testsuite) && !(s['test-case'] || s.testcase),
+  );
+
+  return [
+    ...suites.reduce(reduceTestCases, []),
+    ...subSuites.map(s => processTestSuite(s['test-suite'] || s.testsuite)),
+  ].flat();
 }
 
-function fetchProperties(item, inheritedProperties = []) {
+function fetchProperties(item) {
   const tags = [];
   let title = '';
 
-  const properties = [...inheritedProperties, ...collectProperties(item)];
-  if (!properties.length) return {};
+  if (!item.properties) return {};
+
+  // Handle both single property and array of properties
+  const properties = Array.isArray(item.properties.property)
+    ? item.properties.property
+    : [item.properties.property].filter(Boolean);
 
   const prop = properties.find(p => p.name === 'Description');
   if (prop) title = prop.value;

--- a/src/xmlReader.js
+++ b/src/xmlReader.js
@@ -651,26 +651,34 @@ class XmlReader {
 
 export default XmlReader;
 
-function reduceTestCases(prev, item) {
-  let testCases = item.testcase;
-  if (!testCases) testCases = item['test-case'];
-  if (!Array.isArray(testCases)) {
-    testCases = [testCases];
-  }
+function toArray(value) {
+  if (!value) return [];
+  return Array.isArray(value) ? value : [value];
+}
 
-  // suite inside test case
-  const testCase = item['test-suite']?.['test-case'];
-  if (testCase) {
-    const nestedCases = Array.isArray(testCase) ? testCase : [testCase];
-    testCases.push(...nestedCases);
-  }
+function collectProperties(item) {
+  if (!item?.properties) return [];
+  return Array.isArray(item.properties.property)
+    ? item.properties.property.filter(Boolean)
+    : [item.properties.property].filter(Boolean);
+}
 
+function extractTestsFromSuite(item, parentContext = {}) {
+  const testCases = toArray(item.testcase || item['test-case']);
   const suiteOutput = item['system-out'] || item.output || item.log || '';
   const suiteErr = item['system-err'] || item.output || item.log || '';
+  const context = {
+    file: item.filepath || item.file || item.fullname || item.package || parentContext.file || '',
+    output: [parentContext.output, suiteOutput].filter(Boolean).join('\n\n'),
+    err: [parentContext.err, suiteErr].filter(Boolean).join('\n\n'),
+    properties: [...(parentContext.properties || []), ...collectProperties(item)],
+  };
+  const tests = [];
+
   testCases
     .filter(t => !!t)
     .forEach(testCaseItem => {
-      const file = testCaseItem.file || item.filepath || item.fullname || item.package || '';
+      const file = testCaseItem.file || context.file;
 
       let stack = '';
       let message = '';
@@ -688,7 +696,10 @@ function reduceTestCases(prev, item) {
       const preferClassname = reduceOptions.preferClassname || isParametrized;
 
       // SpecFlow config
-      let { title, tags, testId } = fetchProperties(isParametrized ? item : testCaseItem);
+      let { title, tags, testId } = fetchProperties(
+        isParametrized ? item : testCaseItem,
+        isParametrized ? context.properties : undefined,
+      );
       let example = null;
       const suiteTitle = preferClassname ? testCaseItem.classname : item.name || testCaseItem.classname;
 
@@ -706,9 +717,9 @@ function reduceTestCases(prev, item) {
         title = title.replace(/\(.*?\)/, '').trim();
       }
 
-      stack = `${
-        testCaseItem['system-out'] || testCaseItem.output || testCaseItem.log || ''
-      }\n\n${stack}\n\n${suiteOutput}\n\n${suiteErr}`.trim();
+      stack = `${testCaseItem['system-out'] || testCaseItem.output || testCaseItem.log || ''}\n\n${stack}\n\n${
+        context.output
+      }\n\n${context.err}`.trim();
 
       if (!testId) testId = fetchIdFromOutput(stack);
 
@@ -744,7 +755,7 @@ function reduceTestCases(prev, item) {
       const stackFiles = fetchFilesFromStackTrace(stack);
       files = [...new Set([...files, ...stackFiles])]; // Remove duplicates
 
-      prev.push({
+      tests.push({
         rid,
         file,
         stack,
@@ -764,34 +775,26 @@ function reduceTestCases(prev, item) {
         retry: false,
       });
     });
-  return prev;
+
+  const nestedSuites = [...toArray(item.testsuite), ...toArray(item['test-suite'])];
+  nestedSuites.forEach(nestedSuite => {
+    tests.push(...extractTestsFromSuite(nestedSuite, context));
+  });
+
+  return tests;
 }
 
 function processTestSuite(testsuite) {
   if (!testsuite) return [];
-  if (testsuite.testsuite) return processTestSuite(testsuite.testsuite);
-  if (testsuite['test-suite'] && !testsuite['test-case']) return processTestSuite(testsuite['test-suite']);
-
-  let suites = testsuite;
-  if (!Array.isArray(testsuite)) {
-    suites = [testsuite];
-  }
-
-  const subSuites = suites.filter(s => s['test-suite'] && !testsuite['test-case']);
-
-  return [...subSuites.map(s => processTestSuite(s['test-suite'])), ...suites.reduce(reduceTestCases, [])].flat();
+  return toArray(testsuite).flatMap(suite => extractTestsFromSuite(suite));
 }
 
-function fetchProperties(item) {
+function fetchProperties(item, inheritedProperties = []) {
   const tags = [];
   let title = '';
 
-  if (!item.properties) return {};
-
-  // Handle both single property and array of properties
-  const properties = Array.isArray(item.properties.property)
-    ? item.properties.property
-    : [item.properties.property].filter(Boolean);
+  const properties = [...inheritedProperties, ...collectProperties(item)];
+  if (!properties.length) return {};
 
   const prop = properties.find(p => p.name === 'Description');
   if (prop) title = prop.value;

--- a/tests/unit/data/nested_suites.xml
+++ b/tests/unit/data/nested_suites.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="12" failures="0" skipped="0" time="5.0">
+  <testsuite name="SearchTests" time="4.0" tests="9" failures="0" skipped="0">
+    <testsuite name="SearchSnapshotTests" time="4.0" tests="9" failures="0" skipped="0">
+      <testcase name="resultsLoadingFailed()" classname="SearchSnapshotTests" time="1.0"/>
+      <testcase name="emptySearchWithoutRecentSearches()" classname="SearchSnapshotTests" time="1.0"/>
+      <testcase name="emptySearchWithRecentSearches()" classname="SearchSnapshotTests" time="0.0"/>
+      <testcase name="tagsSuggestions()" classname="SearchSnapshotTests" time="0.0"/>
+      <testcase name="resultsLoading()" classname="SearchSnapshotTests" time="0.0"/>
+      <testcase name="resultsLoaded()" classname="SearchSnapshotTests" time="1.0"/>
+      <testcase name="resultsLoadedAgain()" classname="SearchSnapshotTests" time="0.0"/>
+      <testcase name="resultsLoadedWithItems()" classname="SearchSnapshotTests" time="1.0"/>
+      <testcase name="resultsLoadedEmpty()" classname="SearchSnapshotTests" time="0.0"/>
+    </testsuite>
+    <properties>
+      <property name="Configuration" value="Configuration 1"/>
+      <property name="device" value="iPhone 16 (18.2)"/>
+    </properties>
+  </testsuite>
+  <testsuite name="HomeTests" time="1.0" tests="2" failures="0" skipped="0">
+    <testsuite name="HomeSnapshotTests" time="1.0" tests="2" failures="0" skipped="0">
+      <testcase name="screenLoaded_@T0f90d3c4" classname="HomeSnapshotTests" time="1.0"/>
+      <testcase name="charactersEmpty()" classname="HomeSnapshotTests" time="0.0"/>
+    </testsuite>
+    <properties>
+      <property name="Configuration" value="Configuration 1"/>
+      <property name="device" value="iPhone 16 (18.2)"/>
+    </properties>
+  </testsuite>
+  <testsuite name="AppTests" time="0.0" tests="1" failures="0" skipped="0">
+    <testsuite name="AppTests" time="0.0" tests="1" failures="0" skipped="0">
+      <testcase name="example()" classname="AppTests" time="0.0"/>
+    </testsuite>
+    <properties>
+      <property name="Configuration" value="Configuration 1"/>
+      <property name="device" value="iPhone 16 (18.2)"/>
+    </properties>
+  </testsuite>
+</testsuites>

--- a/tests/unit/xmlReader_test.js
+++ b/tests/unit/xmlReader_test.js
@@ -268,7 +268,7 @@ describe('XML Reader', () => {
     expect(jsonData.status).to.eql('failed');
     const stats = reader.calculateStats();
     expect(stats.status).to.eql('failed');
-    expect(stats.tests_count).to.eql(5);
+    expect(stats.tests_count).to.eql(3);
     expect(jsonData.tests.length).to.eql(stats.tests_count);
 
     reader.fetchSourceCode();

--- a/tests/unit/xmlReader_test.js
+++ b/tests/unit/xmlReader_test.js
@@ -209,6 +209,27 @@ describe('XML Reader', () => {
     expect(skippedTest.title).to.eql('Check Dashboard');
   });
 
+  it('should parse nested JUnit suites from XML', () => {
+    const reader = new XmlReader();
+    const jsonData = reader.parse(path.join(dirname, 'data/nested_suites.xml'));
+
+    expect(jsonData.status).to.eql('passed');
+    expect(jsonData.tests_count).to.eql(12);
+    expect(jsonData.tests.length).to.eql(12);
+
+    const searchTest = jsonData.tests.find(t => t.title === 'resultsLoadingFailed');
+    const homeTest = jsonData.tests.find(t => t.title === 'screenLoaded_@T0f90d3c4');
+    const appTest = jsonData.tests.find(t => t.title === 'example');
+
+    expect(searchTest).to.exist;
+    expect(homeTest).to.exist;
+    expect(appTest).to.exist;
+
+    expect(searchTest.suite_title).to.eql('SearchSnapshotTests');
+    expect(homeTest.suite_title).to.eql('HomeSnapshotTests');
+    expect(appTest.suite_title).to.eql('AppTests');
+  });
+
   it('should parse JUnit params', () => {
     const reader = new XmlReader({ lang: 'java' });
     const jsonData = reader.parse(path.join(dirname, 'data/junit2.xml'));
@@ -247,7 +268,7 @@ describe('XML Reader', () => {
     expect(jsonData.status).to.eql('failed');
     const stats = reader.calculateStats();
     expect(stats.status).to.eql('failed');
-    expect(stats.tests_count).to.eql(3);
+    expect(stats.tests_count).to.eql(5);
     expect(jsonData.tests.length).to.eql(stats.tests_count);
 
     reader.fetchSourceCode();


### PR DESCRIPTION
Fix XML reader handling for nested testsuite structures in JUnit-style reports. The parser now recursively traverses nested suites, collects test cases from any depth, preserves suite-level output context, and adds regression coverage based on the XML sample from https://github.com/testomatio/reporter/issues/549

Added tests for this test                                                                                                       
 