### PR TITLE
fix: handle non-string artifact link/path in HTML pipe

### DIFF
--- a/src/pipe/html.js
+++ b/src/pipe/html.js
@@ -230,8 +230,10 @@ class HtmlPipe {
       ];
 
       test.artifactsUploaded = allPossibleArtifacts.some(artifact => {
-        const link = artifact?.link || artifact?.path;
-        return link && (link.startsWith('http://') || link.startsWith('https://')) && !link.startsWith('file://');
+        let link = artifact?.link || artifact?.path;
+        if (!link) return false;
+        if (typeof link !== 'string') link = String(link);
+        return link.startsWith('http://') || link.startsWith('https://');
       });
 
       normalizeRetries(test);


### PR DESCRIPTION
## Summary
- Fixes `TypeError: link.startsWith is not a function` crash in HTML report generation
- When `artifact.link` or `artifact.path` is a non-string value (e.g. an object), convert it to string before calling `startsWith()`

## Test plan
- [ ] Run HTML report generation with artifacts that have non-string `link`/`path` values
- [ ] Verify normal artifact upload detection still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)