### PR TITLE
Show API message or HTTP status text in error responses

### DIFF
--- a/src/pipe/testomatio.js
+++ b/src/pipe/testomatio.js
@@ -582,7 +582,9 @@ class TestomatioPipe {
     message += pc.bold(`${pc.red(statusCode)} ${method} ${pc.gray(url)}\n`);
 
     const apiMessage = error.response?.data?.message;
-    if (apiMessage) {
+    if (statusCode === 403) {
+      message += `\t${pc.red('Please check your API token. It might be invalid or expired.')}\n`;
+    } else if (apiMessage) {
       message += `\t${pc.red(apiMessage)}\n`;
     } else if (statusText) {
       message += `\t${pc.red(statusText)}\n`;

--- a/src/pipe/testomatio.js
+++ b/src/pipe/testomatio.js
@@ -576,12 +576,16 @@ class TestomatioPipe {
     const statusCode = error.status || error.code || error.response?.status || '<unknown status code>';
     const method = error.response?.config?.method || '<unknown method>';
     const url = String(error.response?.config?.url || '<unknown url>');
+    const statusText = error.response?.statusText || '';
 
     let message = pc.yellow('⚠️ Request to Testomat.io failed:\n');
     message += pc.bold(`${pc.red(statusCode)} ${method} ${pc.gray(url)}\n`);
 
-    if (statusCode === 403) {
-      message += `\t${pc.red('Please check your API token. It might be invalid or expired.')}\n`;
+    const apiMessage = error.response?.data?.message;
+    if (apiMessage) {
+      message += `\t${pc.red(apiMessage)}\n`;
+    } else if (statusText) {
+      message += `\t${pc.red(statusText)}\n`;
     }
 
     message += `\t${pc.bold('response: ')}${pc.gray(responseBody)}\n`;


### PR DESCRIPTION
Display error messages by prioritizing API response messages over official HTTP status texts when Testomat API returns errors
https://github.com/testomatio/reporter/issues/809