### PR TITLE
fixed how grep output is printed in coverage plugin

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -266,6 +266,16 @@ Example:
 TESTOMATIO={API_KEY} TESTOMATIO_TITLE="title for the report" <actual run command>
 ```
 
+#### `TESTOMATIO_DESCRIPTION`
+
+Add a description to the test run. It is appended to the run description on Testomat.io (after any change-aware coverage description), shown in the HTML and Markdown reports, and added — truncated to 1024 characters — to GitHub / GitLab / Bitbucket pull request comments.
+
+Example:
+
+```
+TESTOMATIO={API_KEY} TESTOMATIO_DESCRIPTION="Nightly regression on staging" <actual run command>
+```
+
 #### `TESTOMATIO_LOG_LEVEL`
 
 Control the verbosity of `[TESTOMATIO]` prefixed messages in the test output.

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -116,8 +116,10 @@ program
         debug(`Execution pattern: "${pattern}"`);
 
         if(opts.filterList) {
-          log.info( pc.blue(`Matched test/suite IDs: ${tests.join(', ')}`));
-          if (command) log.info( pc.green(`Full Running Command: ${filteredCommand}`));
+          if (command) log.info(pc.green(`Full Running Command: ${filteredCommand}`));
+          log.info();
+          log.info(`Grep string:`);
+          log.info(`${tests.join(', ')}`);
           return;
         }
 

--- a/src/pipe/bitbucket.js
+++ b/src/pipe/bitbucket.js
@@ -1,5 +1,5 @@
 import { APP_PREFIX, testomatLogoURL } from '../constants.js';
-import { ansiRegExp, isSameTest } from '../utils/utils.js';
+import { ansiRegExp, isSameTest, truncate } from '../utils/utils.js';
 import { statusEmoji, fullName } from '../utils/pipe_utils.js';
 import { Gaxios } from 'gaxios';
 import pc from 'picocolors';
@@ -27,6 +27,7 @@ export class BitbucketPipe {
     this.tests = [];
     // Bitbucket PAT looks like bbpat-*****
     this.token = params.BITBUCKET_ACCESS_TOKEN || process.env.BITBUCKET_ACCESS_TOKEN || this.ENV.BITBUCKET_ACCESS_TOKEN;
+    this.description = params.description || process.env.TESTOMATIO_DESCRIPTION;
     this.hiddenCommentData = `Testomat.io report: ${process.env.BITBUCKET_BRANCH || ''}`;
 
     debug(
@@ -169,6 +170,10 @@ export class BitbucketPipe {
       });
 
     let body = summary;
+
+    if (this.description) {
+      body += `\n\n> ${truncate(this.description, 1024).replace(/\r?\n/g, '\n> ')}`;
+    }
 
     if (failures.length) {
       body += `\n🟥 **Failures (${failures.length})**\n\n* ${failures.join('\n* ')}\n`;

--- a/src/pipe/github.js
+++ b/src/pipe/github.js
@@ -4,7 +4,7 @@ import pc from 'picocolors';
 import humanizeDuration from 'humanize-duration';
 import merge from 'lodash.merge';
 import { testomatLogoURL } from '../constants.js';
-import { ansiRegExp, isSameTest } from '../utils/utils.js';
+import { ansiRegExp, isSameTest, truncate } from '../utils/utils.js';
 import { statusEmoji, fullName } from '../utils/pipe_utils.js';
 import { log } from '../utils/log.js';
 
@@ -22,6 +22,7 @@ class GitHubPipe {
     this.store = store;
     this.tests = [];
     this.token = params.GH_PAT || process.env.GH_PAT;
+    this.description = params.description || process.env.TESTOMATIO_DESCRIPTION;
     this.ref = process.env.GITHUB_REF;
     this.repo = process.env.GITHUB_REPOSITORY;
     this.jobKey = `${process.env.GITHUB_WORKFLOW || ''} / ${process.env.GITHUB_JOB || ''}`;
@@ -143,6 +144,9 @@ class GitHubPipe {
       });
 
     let body = summary;
+    if (this.description) {
+      body += `\n\n> ${truncate(this.description, 1024).replace(/\r?\n/g, '\n> ')}`;
+    }
     const coverageConfiguration = this.store?.coverageConfiguration;
     const isManualRun = this.store?.runKind === 'manual';
     if (isManualRun && coverageConfiguration) {

--- a/src/pipe/gitlab.js
+++ b/src/pipe/gitlab.js
@@ -5,7 +5,7 @@ import humanizeDuration from 'humanize-duration';
 import merge from 'lodash.merge';
 import path from 'path';
 import { APP_PREFIX, testomatLogoURL } from '../constants.js';
-import { ansiRegExp, isSameTest } from '../utils/utils.js';
+import { ansiRegExp, isSameTest, truncate } from '../utils/utils.js';
 import { statusEmoji, fullName } from '../utils/pipe_utils.js';
 import { log } from '../utils/log.js';
 
@@ -27,6 +27,7 @@ class GitLabPipe {
     this.tests = [];
     // GitLab PAT looks like glpat-nKGdja3jsG4850sGksh7
     this.token = params.GITLAB_PAT || process.env.GITLAB_PAT || this.ENV.GITLAB_PAT;
+    this.description = params.description || process.env.TESTOMATIO_DESCRIPTION;
     this.hiddenCommentData = `<!--- testomat.io report ${process.env.CI_JOB_NAME || ''} -->`;
 
     debug(
@@ -144,6 +145,10 @@ class GitLabPipe {
       });
 
     let body = summary;
+
+    if (this.description) {
+      body += `\n\n> ${truncate(this.description, 1024).replace(/\r?\n/g, '\n> ')}`;
+    }
 
     if (failures.length) {
       body += `\n<details>\n<summary><h3>🟥 Failures (${failures.length})</h4></summary>\n\n${failures.join('\n')}\n`;

--- a/src/pipe/html.js
+++ b/src/pipe/html.js
@@ -19,6 +19,7 @@ class HtmlPipe {
   constructor(params, store = {}) {
     this.store = store || {};
     this.title = params.title || process.env.TESTOMATIO_TITLE;
+    this.description = params.description || process.env.TESTOMATIO_DESCRIPTION;
     this.apiKey = params.apiKey || process.env.TESTOMATIO;
     this.isHtml = process.env.TESTOMATIO_HTML_REPORT_SAVE;
 
@@ -254,7 +255,10 @@ class HtmlPipe {
       runUrl: this.store.runUrl || '',
       executionTime: testExecutionSumTime(aggregatedTests),
       executionDate: getCurrentDateTimeFormatted(),
-      description: runParams.description || this.store.coverageDescription || this.store.description || '',
+      description:
+        [runParams.description || this.store.coverageDescription || this.store.description, this.description]
+          .filter(Boolean)
+          .join('\n\n') || '',
       configuration: buildDisplayConfiguration(
         this.configuration || this.store.configuration || runParams.configuration || null,
       ),

--- a/src/pipe/markdown.js
+++ b/src/pipe/markdown.js
@@ -15,6 +15,7 @@ class MarkdownPipe {
   constructor(params, store = {}) {
     this.store = store || {};
     this.title = params.title || process.env.TESTOMATIO_TITLE;
+    this.description = params.description || process.env.TESTOMATIO_DESCRIPTION;
     this.apiKey = params.apiKey || process.env.TESTOMATIO;
     this.isMarkdown = process.env.TESTOMATIO_MARKDOWN_REPORT_SAVE;
 
@@ -134,7 +135,10 @@ class MarkdownPipe {
       isParallel: runParams?.isParallel,
       executionTime: testExecutionSumTime(aggregated),
       executionDate: getCurrentDateTimeFormatted(),
-      description: runParams?.description || this.store.coverageDescription || this.store.description || '',
+      description:
+        [runParams?.description || this.store.coverageDescription || this.store.description, this.description]
+          .filter(Boolean)
+          .join('\n\n') || '',
       configuration: this.configuration || this.store.configuration || runParams?.configuration || null,
       tests: aggregated,
       stats,

--- a/src/pipe/testomatio.js
+++ b/src/pipe/testomatio.js
@@ -83,6 +83,7 @@ class TestomatioPipe {
     this.groupTitle = params.groupTitle || process.env.TESTOMATIO_RUNGROUP_TITLE;
     this.env = process.env.TESTOMATIO_ENV;
     this.label = process.env.TESTOMATIO_LABEL;
+    this.description = params.description || process.env.TESTOMATIO_DESCRIPTION;
 
     // Create a new instance of gaxios with a custom config
     this.client = new Gaxios({
@@ -227,15 +228,17 @@ class TestomatioPipe {
     const accessEvent = process.env.TESTOMATIO_PUBLISH ? 'publish' : null;
 
     const coverageConfiguration = this.store?.coverageConfiguration;
-    let description = null;
+    let coverageDescription = null;
     let configuration = null;
     if (coverageConfiguration && (coverageConfiguration.tests?.length || coverageConfiguration.suites?.length)) {
-      description = this.store?.coverageDescription || null;
+      coverageDescription = this.store?.coverageDescription || null;
       configuration = {
         tests: coverageConfiguration.tests?.map(id => id.replace(/^T/, '')) || [],
         suites: coverageConfiguration.suites?.map(id => id.replace(/^S/, '')) || [],
       };
     }
+    // Run description: coverage-derived block (if any) with the user-provided TESTOMATIO_DESCRIPTION appended after it.
+    const description = [coverageDescription, this.description].filter(Boolean).join('\n\n') || null;
 
     // Merge caller-supplied configuration (e.g. { exploratory: true }) into runParams.configuration.
     // Caller values win on key conflict; coverage-derived tests/suites lists are preserved when not overridden.

--- a/tests/unit/pipes/testomatio_pipe_test.js
+++ b/tests/unit/pipes/testomatio_pipe_test.js
@@ -453,6 +453,85 @@ describe('TestomatioPipe', () => {
       expect(receivedRequestBody).to.not.be.null;
       expect(receivedRequestBody.timeout).to.equal(80000);
     });
+
+    it('should send TESTOMATIO_DESCRIPTION as the run description', async () => {
+      process.env.TESTOMATIO_DESCRIPTION = 'Nightly regression on staging';
+      let receivedRequestBody = null;
+
+      server.on({
+        method: 'POST',
+        path: '/api/reporter',
+        reply: {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            url: 'https://faketestomat.io/report/desc1',
+            uid: 'test-run-desc-1',
+            public_url: 'https://faketestomat.io/public/desc1',
+          }),
+        },
+      });
+
+      const pipe = new TestomatioPipe({
+        apiKey: TESTOMATIO,
+        testomatioUrl: TESTOMATIO_URL,
+        isBatchEnabled: false,
+      });
+
+      const originalRequest = pipe.client.request;
+      pipe.client.request = async function (config) {
+        receivedRequestBody = config;
+        return originalRequest.call(this, config);
+      };
+
+      await pipe.createRun({ kind: 'automated' });
+
+      expect(receivedRequestBody).to.not.be.null;
+      expect(receivedRequestBody.data).to.have.property('description', 'Nightly regression on staging');
+    });
+
+    it('should append TESTOMATIO_DESCRIPTION after the coverage description', async () => {
+      process.env.TESTOMATIO_DESCRIPTION = 'User note';
+      let receivedRequestBody = null;
+
+      server.on({
+        method: 'POST',
+        path: '/api/reporter',
+        reply: {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            url: 'https://faketestomat.io/report/desc2',
+            uid: 'test-run-desc-2',
+            public_url: 'https://faketestomat.io/public/desc2',
+          }),
+        },
+      });
+
+      const store = {
+        coverageConfiguration: { tests: ['T123'], suites: [] },
+        coverageDescription: 'Coverage scope: 1 test affected',
+      };
+      const pipe = new TestomatioPipe(
+        {
+          apiKey: TESTOMATIO,
+          testomatioUrl: TESTOMATIO_URL,
+          isBatchEnabled: false,
+        },
+        store,
+      );
+
+      const originalRequest = pipe.client.request;
+      pipe.client.request = async function (config) {
+        receivedRequestBody = config;
+        return originalRequest.call(this, config);
+      };
+
+      await pipe.createRun({ kind: 'automated' });
+
+      expect(receivedRequestBody).to.not.be.null;
+      expect(receivedRequestBody.data.description).to.equal('Coverage scope: 1 test affected\n\nUser note');
+    });
   });
 
   describe('constructor', () => {

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -267,6 +267,9 @@ export interface RunData {
   /** If duration is pre-set value as in XML tests set it */
   duration?: number;
 
+  /** Free-form run description (from `TESTOMATIO_DESCRIPTION`); appended to any coverage-derived description. */
+  description?: string;
+
   /**
    * An array of `TestData` objects representing the individual test cases in the test run.
    * Used for JUNit report when we don't send the tests in realtime but in a batch as a part of final result */


### PR DESCRIPTION
- added TESTOMATIO_DESCRIPTION param
- improved `filter-list` for coverage report display grep string without ansi chars