### PR TITLE
Exit 1 from --filter-list when no tests match

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -129,6 +129,8 @@ When `--filter-list` is set, the matched test IDs are printed to `stdout` in a f
 
 Set `TESTOMATIO_LOG_LEVEL=INFO` to bring the progress logs back for debugging.
 
+**Exit codes:** `--filter-list` exits `0` when at least one test matched, and `1` when no tests matched or filter resolution failed. CI scripts can branch on the exit code to skip launching the runner when there's nothing to run.
+
 The default format is `ids` (comma-separated). Use `--format` to switch:
 
 - `grep` — alternation wrapped in parens, e.g. `(t1|t2|t3)`

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -119,7 +119,10 @@ program
         const tests = await client.prepareRun(prepareRunParams);
 
         if (!tests || tests.length === 0) {
-          log.info( pc.yellow('No tests found.'));
+          log.warn( pc.yellow('No tests found.'));
+          // Exit non-zero on --filter-list so scripts can detect "nothing to run"
+          // via $? and skip launching the runner.
+          if (opts.filterList) process.exit(1);
           return;
         }
 
@@ -139,7 +142,8 @@ program
         }
       }
       catch (err) {
-        log.info( err.message || err);
+        log.error( err.message || err);
+        if (opts.filterList) process.exit(1);
         return;
       }
     }


### PR DESCRIPTION
## Summary

- `--filter-list` now exits `1` when no tests match the filter or filter resolution fails, and `0` when at least one test is returned. CI scripts can branch on `$?` to skip launching the runner when there's nothing to run.
- Promotes the "No tests found" message from `log.info` to `log.warn` so it still surfaces in the quieter `--format` mode.
- Promotes the catch branch from `log.info` to `log.error` for the same reason.

## Test plan

- [x] Empty filter result exits `1` (verified with `COVERAGE_BY_DEFAULT_GIT_FILE=1` + non-matching coverage.yml)
- [x] Filter resolution error (missing coverage file / bad git diff) exits `1`
- [x] Matching filter result exits `0`, stdout contains the formatted IDs
- [x] Lint passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)