### PR TITLE
Classify CodeceptJS test steps by origin instead of constructor

### DIFF
--- a/src/adapter/codecept.js
+++ b/src/adapter/codecept.js
@@ -490,11 +490,16 @@ function formatHookName(hookName) {
   return hookName.replace(/Hook$/, '');
 }
 
+function getCodeceptStepCategory(origin = 'test') {
+  if (origin === 'hook') return 'hook';
+  return 'user';
+}
+
 // Format CodeceptJS step using its built-in methods
 function formatCodeceptStep(step, screenshotOnFailPath = null) {
   if (!step) return null;
 
-  const category = step.constructor.name === 'HelperStep' ? 'framework' : 'user';
+  const category = getCodeceptStepCategory('test');
   const title = truncate(String(step));
   const duration = step.duration || 0;
 
@@ -548,7 +553,7 @@ function formatHookStep(step) {
   title = truncate(title);
 
   const formattedStep = formatStep({
-    category: 'hook',
+    category: getCodeceptStepCategory('hook'),
     title,
     duration: step.duration || 0,
   });


### PR DESCRIPTION
### Problem
In CodeceptJS run and run-multiple, regular scenario steps can arrive as HelperStep, so the reporter misclassifies them as framework and hides them from the HTML report along with their step-level screenshots. https://github.com/testomatio/reporter/issues/825

### Solution
Classify CodeceptJS steps by execution origin instead of runtime class name: steps from test.steps are treated as user, while hook-collected steps remain hook, which makes HTML rendering consistent across run, run-multiple, and run-workers.