### PR TITLE
Surface Git error and detect missing ref in coverage diff filtering

### DIFF
--- a/src/pipe/coverage.js
+++ b/src/pipe/coverage.js
@@ -260,9 +260,10 @@ class CoveragePipe { // or Changes for the future???
      */
     #getChangedFilesFromGit(cmd) {
         try {
+            // Capture stderr (instead of ignoring it) so Git's actual error is available for diagnostics
             const result = execSync(cmd, {
                 encoding: 'utf-8',
-                stdio: ['pipe', 'pipe', 'ignore']
+                stdio: ['pipe', 'pipe', 'pipe']
             });
 
             return result
@@ -271,16 +272,33 @@ class CoveragePipe { // or Changes for the future???
                 .filter(Boolean);
         }
         catch (err) {
-            const errorMessage = err.message || '';
-            // Git edge: Not a git repository or other error
+            // Prefer Git's own stderr output, fall back to the generic error message
+            const gitOutput = (err.stderr || '').toString().trim();
+            const errorMessage = gitOutput || err.message || '';
+
+            // Git edge: Not a git repository
             if (errorMessage.includes('Not a git repository')) {
-                log.error( '❌ Error: This folder is not a Git repository.');
-            }
-            else {
-                throw new Error(`❌ Git command failed ("${cmd}"):\n`, errorMessage);
+                log.error('❌ Error: This folder is not a Git repository.');
+                return [];
             }
 
-            return [];
+            // Git edge: the branch/ref to diff against is not available locally.
+            // This is common in CI, where a shallow checkout fetches only the current branch.
+            if (
+                errorMessage.includes('unknown revision') ||
+                errorMessage.includes('ambiguous argument') ||
+                errorMessage.includes('bad revision')
+            ) {
+                log.error(`❌ Git command failed ("${cmd}"):\n${errorMessage}`);
+                log.error(
+                    `🔍 Branch "${this.branch}" was not found locally. ` +
+                    `In CI this usually means a shallow checkout — fetch full history first, e.g. ` +
+                    `actions/checkout with "fetch-depth: 0", or run "git fetch origin ${this.branch}:${this.branch}".`
+                );
+                return [];
+            }
+
+            throw new Error(`❌ Git command failed ("${cmd}"):\n${errorMessage}`);
         }
     }
 


### PR DESCRIPTION
## Problem

When using `--filter "coverage:diff=<branch>"`, if the underlying `git diff <branch> --name-only` fails, the reporter printed a blank error and reported **No tests found** — with no indication of *why*.

This is exactly what happened in [this CI run](https://github.com/testomatio/testomatio/actions/runs/26611992345/job/78419700147?pr=8879):

```
[TESTOMATIO] ❌ Git command failed ("git diff master --name-only"):

[TESTOMATIO] 🔍 Pls, check this Git command manually to understand the original problem.
[TESTOMATIO] No tests found.
```

The real cause was a **shallow checkout** in CI (`actions/checkout@v4` defaults to fetching only the PR branch), so `master` did not exist locally and Git failed with `fatal: ambiguous argument 'master': unknown revision...`. That message was invisible.

## Root cause (two bugs in `src/pipe/coverage.js`)

1. **stderr was discarded** — `stdio: ['pipe', 'pipe', 'ignore']` threw away Git's actual error text.
2. **error cause was dropped** — `new Error(msg, errorMessage)`: `Error`'s second argument is an *options object*, not appended to the message, so `errorMessage` was silently ignored.

## Fix

- Capture stderr (`stdio: ['pipe', 'pipe', 'pipe']`) and include Git's real error in the logged message.
- Detect the missing-ref case (`unknown revision` / `ambiguous argument` / `bad revision`) and print an actionable hint.

### Before
```
❌ Git command failed ("git diff master --name-only"):
```

### After
```
❌ Git command failed ("git diff master --name-only"):
fatal: ambiguous argument 'master': unknown revision or path not in the working tree.
🔍 Branch "master" was not found locally. In CI this usually means a shallow checkout — fetch full history first, e.g. actions/checkout with "fetch-depth: 0", or run "git fetch origin master:master".
```

## Testing

Verified against the built `lib/` by running the flow with a non-existent branch — Git's real error and the hint are now shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)