### PR TITLE
Make reporter-cli standalone for Yarn

### DIFF
--- a/.github/workflows/publish-reporter-to-npm.yml
+++ b/.github/workflows/publish-reporter-to-npm.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Sync CLI wrapper version in repository
         run: |
           npm version ${{ github.event.release.tag_name }} --no-git-tag-version
-          npm pkg set "dependencies.@testomatio/reporter=${{ github.event.release.tag_name }}"
+          npm run prepare:standalone
           npm install --package-lock-only
         working-directory: ./packages/reporter-cli
       - name: Commit release version updates
@@ -87,7 +87,8 @@ jobs:
       - name: Sync wrapper version with release version
         run: |
           npm version ${{ github.event.release.tag_name }} --no-git-tag-version
-          npm pkg set "dependencies.@testomatio/reporter=${{ github.event.release.tag_name }}"
+          npm run prepare:standalone
+          npm install --package-lock-only
         working-directory: ./packages/reporter-cli
       - name: Determine npm tag
         id: npm_tag

--- a/packages/reporter-cli/README.md
+++ b/packages/reporter-cli/README.md
@@ -1,10 +1,10 @@
 # testomatio-reporter-cli
 
-Yarn Berry compatible CLI wrapper around `@testomatio/reporter`.
+Yarn Berry compatible standalone CLI for `@testomatio/reporter`.
 
 ## Why
 
-Yarn 4 rejects bin names containing `/`. This wrapper exposes valid command names:
+Yarn 4 rejects bin names containing `/`. This package publishes the reporter CLI with valid command names and does not depend on `@testomatio/reporter`, so Yarn does not link the package that contains the invalid bin name.
 
 - `testomatio-reporter`
 - `reporter`
@@ -25,4 +25,4 @@ npx reporter run "npx playwright test"
 npx testomatio-reporter-cli run "npx playwright test"
 ```
 
-All arguments are forwarded to `@testomatio/reporter` CLI.
+All arguments are forwarded to the bundled reporter CLI.

--- a/packages/reporter-cli/bin/cli.js
+++ b/packages/reporter-cli/bin/cli.js
@@ -1,39 +1,19 @@
 #!/usr/bin/env node
 
 import { spawn } from 'node:child_process';
-import { createRequire } from 'node:module';
 import { existsSync } from 'node:fs';
-import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const require = createRequire(import.meta.url);
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-let targetCli;
-try {
-  const reporterPackageJsonPath = require.resolve('@testomatio/reporter/package.json');
-  const reporterPackageJson = JSON.parse(readFileSync(reporterPackageJsonPath, 'utf8'));
-  const bin = reporterPackageJson.bin || {};
-  const cliRelativePath =
-    bin['testomatio/reporter'] ||
-    bin['testomatio-reporter'] ||
-    Object.values(bin).find(value => typeof value === 'string' && value.includes('cli.js'));
+const standaloneCliPath = path.resolve(__dirname, '../src/bin/cli.js');
+const repositoryCliPath = path.resolve(__dirname, '../../../src/bin/cli.js');
+const targetCli = existsSync(standaloneCliPath) ? standaloneCliPath : repositoryCliPath;
 
-  if (!cliRelativePath) {
-    throw new Error('Cannot detect CLI entry from @testomatio/reporter package.json bin field');
-  }
-
-  targetCli = path.resolve(path.dirname(reporterPackageJsonPath), cliRelativePath);
-} catch (error) {
-  const localCliPath = path.resolve(__dirname, '../../../src/bin/cli.js');
-  if (existsSync(localCliPath)) {
-    targetCli = localCliPath;
-  } else {
-    console.error('[testomatio-reporter] Cannot resolve @testomatio/reporter CLI entrypoint.');
-    console.error(error?.message || error);
-    process.exit(1);
-  }
+if (!existsSync(targetCli)) {
+  console.error('[testomatio-reporter] Cannot resolve standalone CLI entrypoint.');
+  process.exit(1);
 }
 
 const child = spawn(process.execPath, [targetCli, ...process.argv.slice(2)], {

--- a/packages/reporter-cli/package-lock.json
+++ b/packages/reporter-cli/package-lock.json
@@ -9,7 +9,36 @@
       "version": "2.8.4",
       "license": "MIT",
       "dependencies": {
-        "@testomatio/reporter": "2.8.4"
+        "@aws-sdk/client-s3": "^3.279.0",
+        "@aws-sdk/lib-storage": "^3.279.0",
+        "@cucumber/cucumber": "^10.9.0",
+        "@octokit/rest": "^21.1.1",
+        "callsite-record": "^4.1.4",
+        "commander": "^12",
+        "cross-spawn": "^7.0.3",
+        "csv-writer": "^1.6.0",
+        "debug": "4.3.4",
+        "dotenv": "^16.0.1",
+        "fast-xml-parser": "^5.3.4",
+        "file-url": "3.0.0",
+        "filesize": "^10.1.6",
+        "gaxios": ">=6.0 || >=7.0.0-rc.4 || <8",
+        "glob": "^10.3",
+        "handlebars": "^4.7.8",
+        "has-flag": "^5.0.1",
+        "humanize-duration": "^3.27.3",
+        "is-valid-path": "^0.1.1",
+        "js-yaml": "^4.1.1",
+        "json-cycle": "^1.3.0",
+        "lodash.memoize": "^4.1.2",
+        "lodash.merge": "^4.6.2",
+        "marked": "^14.1.4",
+        "minimatch": "^10.2.4",
+        "picocolors": "^1.0.1",
+        "pretty-ms": "^7.0.1",
+        "promise-retry": "^2.0.1",
+        "strip-ansi": "7.1.0",
+        "uuid": "^9.0.0"
       },
       "bin": {
         "reporter": "bin/cli.js",
@@ -2136,53 +2165,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@testomatio/reporter": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/@testomatio/reporter/-/reporter-2.8.4.tgz",
-      "integrity": "sha512-ZJLybDSZS6LiBuAy3ubQlMhmrU+lKX0J+roIYGJCdQnxcIbxuJmNNfdwGSioDQc8e8FQlxMoHLOMJVjwpll0Xg==",
-      "license": "MIT",
-      "dependencies": {
-        "@aws-sdk/client-s3": "^3.279.0",
-        "@aws-sdk/lib-storage": "^3.279.0",
-        "@cucumber/cucumber": "^10.9.0",
-        "@octokit/rest": "^21.1.1",
-        "callsite-record": "^4.1.4",
-        "commander": "^12",
-        "cross-spawn": "^7.0.3",
-        "csv-writer": "^1.6.0",
-        "debug": "4.3.4",
-        "dotenv": "^16.0.1",
-        "fast-xml-parser": "^5.3.4",
-        "file-url": "3.0.0",
-        "filesize": "^10.1.6",
-        "gaxios": ">=6.0 || >=7.0.0-rc.4 || <8",
-        "glob": "^10.3",
-        "handlebars": "^4.7.8",
-        "has-flag": "^5.0.1",
-        "humanize-duration": "^3.27.3",
-        "is-valid-path": "^0.1.1",
-        "js-yaml": "^4.1.1",
-        "json-cycle": "^1.3.0",
-        "lodash.memoize": "^4.1.2",
-        "lodash.merge": "^4.6.2",
-        "marked": "^14.1.4",
-        "minimatch": "^10.2.4",
-        "picocolors": "^1.0.1",
-        "pretty-ms": "^7.0.1",
-        "promise-retry": "^2.0.1",
-        "strip-ansi": "7.1.0",
-        "uuid": "^9.0.0"
-      },
-      "bin": {
-        "report-xml": "src/bin/reportXml.js",
-        "reporter": "src/bin/cli.js",
-        "start-test-run": "src/bin/startTest.js",
-        "upload-artifacts": "src/bin/uploadArtifacts.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@types/lodash": {

--- a/packages/reporter-cli/package.json
+++ b/packages/reporter-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testomatio-reporter-cli",
   "version": "2.8.4",
-  "description": "Yarn Berry compatible CLI wrapper for @testomatio/reporter",
+  "description": "Yarn Berry compatible standalone CLI for @testomatio/reporter",
   "type": "module",
   "bin": {
     "testomatio-reporter-cli": "./bin/cli.js",
@@ -13,13 +13,48 @@
     "url": "https://github.com/testomatio/reporter"
   },
   "files": [
-    "bin"
+    "bin",
+    "src",
+    "types"
   ],
+  "scripts": {
+    "prepare:standalone": "node ./scripts/prepare-standalone.js",
+    "prepack": "node ./scripts/prepare-standalone.js"
+  },
   "engines": {
     "node": ">=18"
   },
   "dependencies": {
-    "@testomatio/reporter": "2.8.4"
+    "@aws-sdk/client-s3": "^3.279.0",
+    "@aws-sdk/lib-storage": "^3.279.0",
+    "@cucumber/cucumber": "^10.9.0",
+    "@octokit/rest": "^21.1.1",
+    "callsite-record": "^4.1.4",
+    "commander": "^12",
+    "cross-spawn": "^7.0.3",
+    "csv-writer": "^1.6.0",
+    "debug": "4.3.4",
+    "dotenv": "^16.0.1",
+    "fast-xml-parser": "^5.3.4",
+    "file-url": "3.0.0",
+    "filesize": "^10.1.6",
+    "gaxios": ">=6.0 || >=7.0.0-rc.4 || <8",
+    "glob": "^10.3",
+    "handlebars": "^4.7.8",
+    "has-flag": "^5.0.1",
+    "humanize-duration": "^3.27.3",
+    "is-valid-path": "^0.1.1",
+    "js-yaml": "^4.1.1",
+    "json-cycle": "^1.3.0",
+    "lodash.memoize": "^4.1.2",
+    "lodash.merge": "^4.6.2",
+    "marked": "^14.1.4",
+    "minimatch": "^10.2.4",
+    "picocolors": "^1.0.1",
+    "pretty-ms": "^7.0.1",
+    "promise-retry": "^2.0.1",
+    "strip-ansi": "7.1.0",
+    "uuid": "^9.0.0"
   },
   "license": "MIT"
 }

--- a/packages/reporter-cli/scripts/prepare-standalone.js
+++ b/packages/reporter-cli/scripts/prepare-standalone.js
@@ -9,21 +9,6 @@ const repositoryRoot = path.resolve(packageRoot, '..', '..');
 const rootPackagePath = path.join(repositoryRoot, 'package.json');
 const cliPackagePath = path.join(packageRoot, 'package.json');
 
-const entrypoints = [
-  'src/bin/cli.js',
-  'src/bin/reportXml.js',
-  'src/bin/startTest.js',
-  'src/bin/uploadArtifacts.js',
-];
-
-const assetDirectories = [
-  'src/template',
-  'types',
-];
-
-const importSpecifierPattern =
-  /(?:import|export)\s+(?:[^'"]*?\s+from\s+)?['"]([^'"]+)['"]|import\(\s*['"]([^'"]+)['"]\s*\)/g;
-
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
 }
@@ -39,75 +24,11 @@ function copyDirectory(source, destination) {
   fs.cpSync(source, destination, { recursive: true });
 }
 
-function copyFile(source, destination) {
-  if (!fs.existsSync(source)) return;
-
-  fs.mkdirSync(path.dirname(destination), { recursive: true });
-  fs.copyFileSync(source, destination);
-}
-
-function toPackageRelativePath(filePath) {
-  return path.relative(repositoryRoot, filePath).replace(/\\/g, '/');
-}
-
-function resolveRelativeImport(importerPath, specifier) {
-  if (!specifier.startsWith('.')) return null;
-
-  const basePath = path.resolve(path.dirname(importerPath), specifier);
-  const candidates = [
-    basePath,
-    `${basePath}.js`,
-    `${basePath}.mjs`,
-    `${basePath}.cjs`,
-    `${basePath}.json`,
-    path.join(basePath, 'index.js'),
-  ];
-
-  return candidates.find(candidate => fs.existsSync(candidate) && fs.statSync(candidate).isFile()) || null;
-}
-
-function collectRelativeDependencies(entrypoint) {
-  const files = new Set();
-  const queue = [path.join(repositoryRoot, entrypoint)];
-
-  while (queue.length) {
-    const filePath = queue.pop();
-    if (!filePath || files.has(filePath)) continue;
-
-    files.add(filePath);
-
-    if (!/\.(?:js|mjs|cjs)$/.test(filePath)) continue;
-
-    const source = fs.readFileSync(filePath, 'utf8');
-    importSpecifierPattern.lastIndex = 0;
-
-    for (const match of source.matchAll(importSpecifierPattern)) {
-      const specifier = match[1] || match[2];
-      const resolved = resolveRelativeImport(filePath, specifier);
-      if (resolved) queue.push(resolved);
-    }
-  }
-
-  return files;
-}
-
 fs.rmSync(path.join(packageRoot, 'src'), { recursive: true, force: true });
 fs.rmSync(path.join(packageRoot, 'types'), { recursive: true, force: true });
 
-const sourceFiles = new Set();
-for (const entrypoint of entrypoints) {
-  for (const file of collectRelativeDependencies(entrypoint)) {
-    sourceFiles.add(file);
-  }
-}
-
-for (const file of sourceFiles) {
-  copyFile(file, path.join(packageRoot, toPackageRelativePath(file)));
-}
-
-for (const directory of assetDirectories) {
-  copyDirectory(path.join(repositoryRoot, directory), path.join(packageRoot, directory));
-}
+copyDirectory(path.join(repositoryRoot, 'src'), path.join(packageRoot, 'src'));
+copyDirectory(path.join(repositoryRoot, 'types'), path.join(packageRoot, 'types'));
 
 const rootPackage = readJson(rootPackagePath);
 const cliPackage = readJson(cliPackagePath);

--- a/packages/reporter-cli/scripts/prepare-standalone.js
+++ b/packages/reporter-cli/scripts/prepare-standalone.js
@@ -1,0 +1,76 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(__dirname, '..');
+const repositoryRoot = path.resolve(packageRoot, '..', '..');
+
+const rootPackagePath = path.join(repositoryRoot, 'package.json');
+const cliPackagePath = path.join(packageRoot, 'package.json');
+
+const sourceDirectories = [
+  'src/bin',
+  'src/pipe',
+  'src/utils',
+  'src/junit-adapter',
+  'src/services',
+  'src/template',
+  'src/adapter/utils',
+  'types',
+];
+
+const sourceFiles = [
+  'src/client.js',
+  'src/config.js',
+  'src/constants.js',
+  'src/data-storage.js',
+  'src/helpers.js',
+  'src/output.js',
+  'src/replay.js',
+  'src/uploader.js',
+  'src/xmlReader.js',
+];
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, data) {
+  fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+function copyDirectory(source, destination) {
+  if (!fs.existsSync(source)) return;
+
+  fs.rmSync(destination, { recursive: true, force: true });
+  fs.cpSync(source, destination, { recursive: true });
+}
+
+fs.rmSync(path.join(packageRoot, 'src'), { recursive: true, force: true });
+fs.rmSync(path.join(packageRoot, 'types'), { recursive: true, force: true });
+
+for (const directory of sourceDirectories) {
+  copyDirectory(path.join(repositoryRoot, directory), path.join(packageRoot, directory));
+}
+
+for (const file of sourceFiles) {
+  const source = path.join(repositoryRoot, file);
+  const destination = path.join(packageRoot, file);
+  if (!fs.existsSync(source)) continue;
+
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.copyFileSync(source, destination);
+}
+
+const rootPackage = readJson(rootPackagePath);
+const cliPackage = readJson(cliPackagePath);
+
+cliPackage.dependencies = { ...rootPackage.dependencies };
+delete cliPackage.dependencies['@testomatio/reporter'];
+
+cliPackage.files = ['bin', 'src', 'types'];
+
+writeJson(cliPackagePath, cliPackage);
+
+console.log('Prepared standalone testomatio-reporter-cli package.');

--- a/packages/reporter-cli/scripts/prepare-standalone.js
+++ b/packages/reporter-cli/scripts/prepare-standalone.js
@@ -9,28 +9,20 @@ const repositoryRoot = path.resolve(packageRoot, '..', '..');
 const rootPackagePath = path.join(repositoryRoot, 'package.json');
 const cliPackagePath = path.join(packageRoot, 'package.json');
 
-const sourceDirectories = [
-  'src/bin',
-  'src/pipe',
-  'src/utils',
-  'src/junit-adapter',
-  'src/services',
+const entrypoints = [
+  'src/bin/cli.js',
+  'src/bin/reportXml.js',
+  'src/bin/startTest.js',
+  'src/bin/uploadArtifacts.js',
+];
+
+const assetDirectories = [
   'src/template',
-  'src/adapter/utils',
   'types',
 ];
 
-const sourceFiles = [
-  'src/client.js',
-  'src/config.js',
-  'src/constants.js',
-  'src/data-storage.js',
-  'src/helpers.js',
-  'src/output.js',
-  'src/replay.js',
-  'src/uploader.js',
-  'src/xmlReader.js',
-];
+const importSpecifierPattern =
+  /(?:import|export)\s+(?:[^'"]*?\s+from\s+)?['"]([^'"]+)['"]|import\(\s*['"]([^'"]+)['"]\s*\)/g;
 
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
@@ -47,20 +39,74 @@ function copyDirectory(source, destination) {
   fs.cpSync(source, destination, { recursive: true });
 }
 
-fs.rmSync(path.join(packageRoot, 'src'), { recursive: true, force: true });
-fs.rmSync(path.join(packageRoot, 'types'), { recursive: true, force: true });
-
-for (const directory of sourceDirectories) {
-  copyDirectory(path.join(repositoryRoot, directory), path.join(packageRoot, directory));
-}
-
-for (const file of sourceFiles) {
-  const source = path.join(repositoryRoot, file);
-  const destination = path.join(packageRoot, file);
-  if (!fs.existsSync(source)) continue;
+function copyFile(source, destination) {
+  if (!fs.existsSync(source)) return;
 
   fs.mkdirSync(path.dirname(destination), { recursive: true });
   fs.copyFileSync(source, destination);
+}
+
+function toPackageRelativePath(filePath) {
+  return path.relative(repositoryRoot, filePath).replace(/\\/g, '/');
+}
+
+function resolveRelativeImport(importerPath, specifier) {
+  if (!specifier.startsWith('.')) return null;
+
+  const basePath = path.resolve(path.dirname(importerPath), specifier);
+  const candidates = [
+    basePath,
+    `${basePath}.js`,
+    `${basePath}.mjs`,
+    `${basePath}.cjs`,
+    `${basePath}.json`,
+    path.join(basePath, 'index.js'),
+  ];
+
+  return candidates.find(candidate => fs.existsSync(candidate) && fs.statSync(candidate).isFile()) || null;
+}
+
+function collectRelativeDependencies(entrypoint) {
+  const files = new Set();
+  const queue = [path.join(repositoryRoot, entrypoint)];
+
+  while (queue.length) {
+    const filePath = queue.pop();
+    if (!filePath || files.has(filePath)) continue;
+
+    files.add(filePath);
+
+    if (!/\.(?:js|mjs|cjs)$/.test(filePath)) continue;
+
+    const source = fs.readFileSync(filePath, 'utf8');
+    importSpecifierPattern.lastIndex = 0;
+
+    for (const match of source.matchAll(importSpecifierPattern)) {
+      const specifier = match[1] || match[2];
+      const resolved = resolveRelativeImport(filePath, specifier);
+      if (resolved) queue.push(resolved);
+    }
+  }
+
+  return files;
+}
+
+fs.rmSync(path.join(packageRoot, 'src'), { recursive: true, force: true });
+fs.rmSync(path.join(packageRoot, 'types'), { recursive: true, force: true });
+
+const sourceFiles = new Set();
+for (const entrypoint of entrypoints) {
+  for (const file of collectRelativeDependencies(entrypoint)) {
+    sourceFiles.add(file);
+  }
+}
+
+for (const file of sourceFiles) {
+  copyFile(file, path.join(packageRoot, toPackageRelativePath(file)));
+}
+
+for (const directory of assetDirectories) {
+  copyDirectory(path.join(repositoryRoot, directory), path.join(packageRoot, directory));
 }
 
 const rootPackage = readJson(rootPackagePath);

--- a/tests/unit/reporter_cli_wrapper_test.js
+++ b/tests/unit/reporter_cli_wrapper_test.js
@@ -4,9 +4,10 @@ import os from 'os';
 import path from 'path';
 import { spawn } from 'node:child_process';
 
-const wrapperCliPath = path.resolve(process.cwd(), 'packages/reporter-cli/bin/cli.js');
+const repositoryWrapperCliPath = path.resolve(process.cwd(), 'packages/reporter-cli/bin/cli.js');
+const wrapperPackageJsonPath = path.resolve(process.cwd(), 'packages/reporter-cli/package.json');
 
-function runWrapper(args, env = {}) {
+function runWrapper(wrapperCliPath, args, env = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [wrapperCliPath, ...args], {
       env: { ...process.env, ...env },
@@ -45,30 +46,20 @@ function extractJson(stdout) {
 
 describe('reporter-cli wrapper', () => {
   let tempDir;
-  let reporterPackageDir;
+  let wrapperCliPath;
 
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reporter-cli-wrapper-test-'));
-    reporterPackageDir = path.join(tempDir, '@testomatio', 'reporter');
-    fs.mkdirSync(path.join(reporterPackageDir, 'bin'), { recursive: true });
+    const binDir = path.join(tempDir, 'bin');
+    const srcBinDir = path.join(tempDir, 'src', 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.mkdirSync(srcBinDir, { recursive: true });
+
+    wrapperCliPath = path.join(binDir, 'cli.js');
+    fs.copyFileSync(repositoryWrapperCliPath, wrapperCliPath);
 
     fs.writeFileSync(
-      path.join(reporterPackageDir, 'package.json'),
-      JSON.stringify(
-        {
-          name: '@testomatio/reporter',
-          version: '9.9.9',
-          bin: {
-            'testomatio/reporter': './bin/cli.js',
-          },
-        },
-        null,
-        2,
-      ),
-    );
-
-    fs.writeFileSync(
-      path.join(reporterPackageDir, 'bin', 'cli.js'),
+      path.join(srcBinDir, 'cli.js'),
       [
         "const payload = {",
         '  argv: process.argv.slice(2),',
@@ -89,8 +80,7 @@ describe('reporter-cli wrapper', () => {
   });
 
   it('forwards args/env for run command with wdio style command', async () => {
-    const result = await runWrapper(['run', 'wdio --spec tests/e2e/smoke.e2e.js'], {
-      NODE_PATH: tempDir,
+    const result = await runWrapper(wrapperCliPath, ['run', 'wdio --spec tests/e2e/smoke.e2e.js'], {
       CUSTOM_ENV: 'from-wrapper',
       TESTOMATIO_CUSTOM: 'tstmt-value',
     });
@@ -104,9 +94,9 @@ describe('reporter-cli wrapper', () => {
 
   it('forwards args/env for run command with codeceptjs style command', async () => {
     const result = await runWrapper(
+      wrapperCliPath,
       ['run', 'codeceptjs run --grep @smoke --config codecept.conf.js'],
       {
-        NODE_PATH: tempDir,
         CUSTOM_ENV: 'codecept',
         TESTOMATIO_CUSTOM: 'codecept-env',
       },
@@ -117,5 +107,11 @@ describe('reporter-cli wrapper', () => {
     expect(payload.argv).to.deep.equal(['run', 'codeceptjs run --grep @smoke --config codecept.conf.js']);
     expect(payload.env.CUSTOM_ENV).to.equal('codecept');
     expect(payload.env.TESTOMATIO_CUSTOM).to.equal('codecept-env');
+  });
+
+  it('does not depend on @testomatio/reporter package', () => {
+    const packageJson = JSON.parse(fs.readFileSync(wrapperPackageJsonPath, 'utf8'));
+
+    expect(packageJson.dependencies).to.not.have.property('@testomatio/reporter');
   });
 });


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                    
  - make `testomatio-reporter-cli` standalone instead of depending on `@testomatio/reporter`                                                                                                    
  - copy required CLI runtime files during pack/publish                                                                                                                                         
  - update release workflow and tests for standalone CLI publishing