### PR TITLE
add playwright fast upload fix

### DIFF
--- a/src/adapter/playwright.js
+++ b/src/adapter/playwright.js
@@ -14,13 +14,13 @@ import { fetchLinksFromLogs } from './utils/playwright.js';
 import { formatStep, addStatusToStep, addArtifactsToStep } from './utils/step-formatter.js';
 import { log } from '../utils/log.js';
 
-const reportTestPromises = [];
-
 class PlaywrightReporter {
   constructor(config = {}) {
     this.client = new TestomatioClient({ apiKey: config?.apiKey });
 
     this.uploads = [];
+    this.reportTestPromises = [];
+    this.runPromise = Promise.resolve();
   }
 
   onBegin(config, suite) {
@@ -29,7 +29,9 @@ class PlaywrightReporter {
     if (!this.client) return;
     this.suite = suite;
     this.config = config;
-    this.client.createRun();
+    this.uploads = [];
+    this.reportTestPromises = [];
+    this.runPromise = this.client.createRun();
   }
 
   onTestBegin(testInfo) {
@@ -41,6 +43,7 @@ class PlaywrightReporter {
     // test.parent.project().__projectId
 
     if (!this.client) return;
+    await this.runPromise;
 
     const { title } = test;
     const { error, duration } = result;
@@ -149,7 +152,7 @@ class PlaywrightReporter {
     // remove empty uploads
     this.uploads = this.uploads.filter(anUpload => anUpload.files.length);
 
-    reportTestPromises.push(reportTestPromise);
+    this.reportTestPromises.push(reportTestPromise);
   }
 
   #getArtifactPath(artifact) {
@@ -173,7 +176,8 @@ class PlaywrightReporter {
   async onEnd(result) {
     if (!this.client) return;
 
-    await Promise.all(reportTestPromises);
+    await this.runPromise;
+    await Promise.all(this.reportTestPromises);
 
     if (this.uploads.length) {
       if (this.client.uploader.isEnabled) log.info(`🎞️ Uploading ${this.uploads.length} files...`);

--- a/tests/unit/playwright_reporter_fast_artifacts_test.js
+++ b/tests/unit/playwright_reporter_fast_artifacts_test.js
@@ -1,0 +1,70 @@
+import { expect } from 'chai';
+import PlaywrightReporter from '../../src/adapter/playwright.js';
+
+describe('PlaywrightReporter fast artifacts', () => {
+  it('waits for run creation before reporting a fast test with attachments', async () => {
+    let resolveCreateRun;
+    let runCreated = false;
+    const createRunPromise = new Promise(resolve => {
+      resolveCreateRun = () => {
+        runCreated = true;
+        resolve();
+      };
+    });
+    const addTestRunCalls = [];
+
+    const reporter = new PlaywrightReporter();
+    reporter.client = {
+      createRun: () => createRunPromise,
+      addTestRun: async (status, data) => {
+        if (!runCreated) throw new Error('addTestRun was called before createRun completed');
+        addTestRunCalls.push({ status, data });
+      },
+    };
+
+    reporter.onBegin({ outputDir: '', projects: [{ outputDir: '' }] }, {});
+
+    const testEndPromise = reporter.onTestEnd(
+      {
+        title: 'fast test with artifact',
+        id: 'fast-test',
+        annotations: [],
+        tags: [],
+        expectedStatus: 'passed',
+        location: { file: 'tests/fast.spec.js' },
+        parent: {
+          title: 'fast suite',
+          project: () => ({
+            dependencies: [],
+            metadata: {},
+            name: 'chromium',
+            use: {},
+          }),
+        },
+      },
+      {
+        attachments: [
+          {
+            body: Buffer.from('artifact'),
+            contentType: 'image/png',
+            name: 'screenshot',
+          },
+        ],
+        duration: 10,
+        status: 'passed',
+        stderr: [],
+        stdout: [],
+        steps: [],
+      },
+    );
+
+    await Promise.resolve();
+    expect(addTestRunCalls).to.have.length(0);
+
+    resolveCreateRun();
+    await testEndPromise;
+
+    expect(addTestRunCalls).to.have.length(1);
+    expect(addTestRunCalls[0].data.files).to.have.length(1);
+  });
+});


### PR DESCRIPTION
## Summary                                                                                                                                                                                        
  - wait for Playwright `createRun()` before processing test results and attachments                                                                                                                
  - move Playwright pending report promises from module scope to reporter instance                                                                                                                  
  - add unit test
  
  https://github.com/testomatio/reporter/issues/836