### PR TITLE
Fix playwright annotations multiple logic

### DIFF
--- a/example/playwright/tests/simple.spec.js
+++ b/example/playwright/tests/simple.spec.js
@@ -34,3 +34,16 @@ test(
     expect(true).toBe(true);
   },
 );
+
+test(
+  'test with duplicate annotation types',
+  {
+    annotation: [
+      { type: 'Issue', description: 'https://issues.example.com/DEMO-101' },
+      { type: 'Issue', description: 'https://issues.example.com/DEMO-102' },
+    ],
+  },
+  async () => {
+    expect(true).toBe(true);
+  },
+);

--- a/src/adapter/playwright.js
+++ b/src/adapter/playwright.js
@@ -133,7 +133,11 @@ class PlaywrightReporter {
         ...meta,
         ...project.metadata, // metadata has any type (in playwright), but we will stringify it in client.js
         ...test.annotations?.reduce((acc, annotation) => {
-          acc[annotation.type] = annotation.description;
+          if (acc[annotation.type]) {
+            acc[annotation.type] = `${acc[annotation.type]}, ${annotation.description}`;
+          } else {
+            acc[annotation.type] = annotation.description;
+          }
           return acc;
         }, {}),
       },

--- a/tests/adapter/playwright.test.js
+++ b/tests/adapter/playwright.test.js
@@ -115,6 +115,19 @@ describe('Playwright Adapter Tests', function () {
       expect(testWithBugAnnotation).to.exist;
       expect(testWithBugAnnotation.testId.meta.bug).to.include('intentional failure');
     });
+
+    it('should preserve all annotations with duplicate types', async () => {
+      const { testEntries } = await runPlaywrightTest();
+
+      const testWithDuplicateAnnotations = testEntries.find(
+        entry => entry.testId && entry.testId.meta && entry.testId.meta.Issue,
+      );
+
+      expect(testWithDuplicateAnnotations).to.exist;
+      const issueValue = testWithDuplicateAnnotations.testId.meta.Issue;
+      expect(issueValue).to.include('DEMO-101');
+      expect(issueValue).to.include('DEMO-102');
+    });
   });
 
   describe('Relative File Paths', () => {


### PR DESCRIPTION
## Summary
Added support for multiple annotation additions

## Example:
```
import { test, expect } from '@playwright/test';

test('two issue annotations', {
  annotation: [
    { type: 'Issue', description: 'https://issues.example.com/DEMO-101' },
    { type: 'Issue', description: 'https://issues.example.com/DEMO-102' },
  ],
}, async () => {
  expect(true).toBe(true);
});
```