### PR TITLE
fix: batch in xml; refactor batching

### DIFF
--- a/docs/debug-file-format.md
+++ b/docs/debug-file-format.md
@@ -111,7 +111,7 @@ Every entry in the debug file follows this base structure:
     "title": "Test Run Title",
     "env": "staging",
     "parallel": true,
-    "isBatchEnabled": true
+    "batchMode": "auto"
   }
 }
 ```
@@ -213,7 +213,7 @@ Every entry in the debug file follows this base structure:
 | `params.env`            | string  | No       | Environment name                        |
 | `params.parallel`       | boolean | No       | Whether run supports parallel execution |
 | `params.status`         | string  | No       | Run status (for finishRun)              |
-| `params.isBatchEnabled` | boolean | No       | Whether batch upload is enabled         |
+| `params.batchMode`      | string  | No       | Batch upload mode: `auto`, `manual`, or `disabled` |
 
 #### `addTest` / `addTestsBatch`
 
@@ -377,8 +377,7 @@ for (const line of lines) {
 ### Batch Processing
 
 - Tests can be logged individually or in batches
-- Batch interval is 5 seconds by default
-- Batch upload is triggered on intervals and during finishRun
+- Batched tests are gathered in memory and written on `sync()` / `finishRun()`
 
 ### Error Handling
 

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -6,7 +6,7 @@ import { glob } from 'glob';
 import createDebugMessages from 'debug';
 import TestomatClient from '../client.js';
 import XmlReader from '../xmlReader.js';
-import { APP_PREFIX, STATUS, DEBUG_FILE } from '../constants.js';
+import { APP_PREFIX, STATUS, DEBUG_FILE, BATCH_MODE } from '../constants.js';
 import { cleanLatestRunId, getPackageVersion, applyFilter } from '../utils/utils.js';
 import { config } from '../config.js';
 import { readLatestRunId } from '../utils/utils.js';
@@ -369,7 +369,7 @@ program
     const client = new TestomatClient({
       apiKey,
       runId,
-      batchMode: 'disabled',
+      batchMode: BATCH_MODE.DISABLED,
     });
 
     let testruns = client.uploader.readUploadedFiles(runId);

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -369,7 +369,7 @@ program
     const client = new TestomatClient({
       apiKey,
       runId,
-      isBatchEnabled: false,
+      batchMode: 'disabled',
     });
 
     let testruns = client.uploader.readUploadedFiles(runId);

--- a/src/bin/uploadArtifacts.js
+++ b/src/bin/uploadArtifacts.js
@@ -37,7 +37,7 @@ program
     const client = new TestomatClient({
       apiKey,
       runId,
-      isBatchEnabled: false,
+      batchMode: 'disabled',
     });
     let testruns = client.uploader.readUploadedFiles(process.env.TESTOMATIO_RUN);
 

--- a/src/bin/uploadArtifacts.js
+++ b/src/bin/uploadArtifacts.js
@@ -9,6 +9,7 @@ import { config } from '../config.js';
 import { readLatestRunId } from '../utils/utils.js';
 import dotenv from 'dotenv';
 import { log } from '../utils/log.js';
+import { BATCH_MODE } from '../constants.js';
 
 const debug = createDebugMessages('@testomatio/reporter:upload-cli');
 const version = getPackageVersion();
@@ -37,7 +38,7 @@ program
     const client = new TestomatClient({
       apiKey,
       runId,
-      batchMode: 'disabled',
+      batchMode: BATCH_MODE.DISABLED,
     });
     let testruns = client.uploader.readUploadedFiles(process.env.TESTOMATIO_RUN);
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -28,6 +28,14 @@ const STATUS = {
   SKIPPED: 'skipped',
   FINISHED: 'finished',
 };
+
+// batch upload mode
+/** @type {{ AUTO: 'auto', MANUAL: 'manual', DISABLED: 'disabled' }} */
+const BATCH_MODE = {
+  AUTO: 'auto',
+  MANUAL: 'manual',
+  DISABLED: 'disabled',
+};
 // html pipe var
 const HTML_REPORT = {
   FOLDER: 'html-report',
@@ -61,6 +69,7 @@ export {
   TESTOMAT_TMP_STORAGE_DIR,
   CSV_HEADERS,
   STATUS,
+  BATCH_MODE,
   HTML_REPORT,
   MARKDOWN_REPORT,
   REQUEST_TIMEOUT,

--- a/src/pipe/debug.js
+++ b/src/pipe/debug.js
@@ -54,6 +54,13 @@ export class DebugPipe {
       this.logToFile({ datetime: new Date().toISOString(), timestamp: Date.now() });
       this.logToFile({ data: 'variables', testomatioEnvVars: this.testomatioEnvVars });
       this.logToFile({ data: 'store', store: this.store || {} });
+
+      // Safety net for hook failures (e.g. a failing AfterSuite) that abort the run
+      // before finishRun: buffered tests would otherwise be lost. The handler is
+      // attached lazily when the first test is buffered and detached once flushed,
+      // so processes that create many pipes don't pile up `exit` listeners.
+      this.flushOnExit = () => this.flushBufferedTests();
+      this.exitListenerAttached = false;
     }
   }
 
@@ -87,6 +94,10 @@ export class DebugPipe {
   async addTest(data) {
     if (!this.isEnabled) return;
     this.tests.push(data);
+    if (!this.exitListenerAttached) {
+      process.once('exit', this.flushOnExit);
+      this.exitListenerAttached = true;
+    }
   }
 
   async finishRun(params) {
@@ -101,12 +112,28 @@ export class DebugPipe {
   }
 
   async sync() {
+    this.flushBufferedTests();
+  }
+
+  /**
+   * Writes any buffered tests to the debug file as a single batch.
+   * Runs synchronously so it can also be invoked from a process `exit` handler,
+   * which is the only chance to persist tests when a hook failure (e.g. a failing
+   * AfterSuite) prevents `finishRun` from being reached. Idempotent: the buffer is
+   * drained on flush, so a later `finishRun`/exit flush is a no-op.
+   */
+  flushBufferedTests() {
     if (!this.isEnabled || !this.tests.length) return;
 
     const tests = this.tests.splice(0);
     const logData = { action: 'addTestsBatch', tests };
     if (this.store.runId) logData.runId = this.store.runId;
     this.logToFile(logData);
+
+    if (this.exitListenerAttached) {
+      process.removeListener('exit', this.flushOnExit);
+      this.exitListenerAttached = false;
+    }
   }
 
   toString() {

--- a/src/pipe/debug.js
+++ b/src/pipe/debug.js
@@ -14,13 +14,7 @@ export class DebugPipe {
 
     this.isEnabled = !!process.env.TESTOMATIO_DEBUG || !!process.env.DEBUG;
     if (this.isEnabled) {
-      this.batch = {
-        isEnabled: this.params.isBatchEnabled ?? !process.env.TESTOMATIO_DISABLE_BATCH_UPLOAD,
-        intervalFunction: null,
-        intervalTime: 5000,
-        tests: [],
-        batchIndex: 0,
-      };
+      this.tests = [];
       const suffix = process.env.TESTOMATIO_REPLAY ? 'replay' : '';
       const paths = getDebugFilePath(suffix);
       this.logFilePath = paths.tmp;
@@ -60,8 +54,6 @@ export class DebugPipe {
       this.logToFile({ datetime: new Date().toISOString(), timestamp: Date.now() });
       this.logToFile({ data: 'variables', testomatioEnvVars: this.testomatioEnvVars });
       this.logToFile({ data: 'store', store: this.store || {} });
-      // Bind batchUpload to the instance
-      this.batchUpload = this.batchUpload.bind(this);
     }
   }
 
@@ -88,42 +80,18 @@ export class DebugPipe {
 
   async createRun(params = {}) {
     if (!this.isEnabled) return;
-    if (params.isBatchEnabled === true || params.isBatchEnabled === false) this.batch.isEnabled = params.isBatchEnabled;
-
-    if (!this.isEnabled) return {};
-    if (this.batch.isEnabled) this.batch.intervalFunction = setInterval(this.batchUpload, this.batch.intervalTime);
 
     this.logToFile({ action: 'createRun', params });
   }
 
   async addTest(data) {
     if (!this.isEnabled) return;
-
-    if (!this.batch.isEnabled) {
-      const logData = { action: 'addTest', testId: data };
-      if (this.store.runId) logData.runId = this.store.runId;
-      this.logToFile(logData);
-    } else this.batch.tests.push(data);
-
-    if (!this.batch.intervalFunction) await this.batchUpload();
-  }
-
-  async batchUpload() {
-    this.batch.batchIndex++;
-    if (!this.batch.isEnabled) return;
-    if (!this.batch.tests.length) return;
-
-    const testsToSend = this.batch.tests.splice(0);
-
-    const logData = { action: 'addTestsBatch', tests: testsToSend };
-    if (this.store.runId) logData.runId = this.store.runId;
-    this.logToFile(logData);
+    this.tests.push(data);
   }
 
   async finishRun(params) {
     if (!this.isEnabled) return;
     await this.sync();
-    if (this.batch.intervalFunction) clearInterval(this.batch.intervalFunction);
     const logData = { action: 'finishRun', params };
     if (this.store.runId) logData.runId = this.store.runId;
     this.logToFile(logData);
@@ -133,8 +101,12 @@ export class DebugPipe {
   }
 
   async sync() {
-    if (!this.isEnabled) return;
-    await this.batchUpload();
+    if (!this.isEnabled || !this.tests.length) return;
+
+    const tests = this.tests.splice(0);
+    const logData = { action: 'addTestsBatch', tests };
+    if (this.store.runId) logData.runId = this.store.runId;
+    this.logToFile(logData);
   }
 
   toString() {

--- a/src/pipe/testomatio.js
+++ b/src/pipe/testomatio.js
@@ -5,6 +5,7 @@ import JsonCycle from 'json-cycle';
 import {
   APP_PREFIX,
   STATUS,
+  BATCH_MODE,
   REQUEST_TIMEOUT,
   getCreateRunRequestTimeout,
   REPORTER_REQUEST_RETRIES,
@@ -60,7 +61,7 @@ class TestomatioPipe {
        * - `manual`: buffer tests and upload only when `sync()` is invoked manually.
        * - `disabled`: send one test per request, no batching.
        */
-      mode: params.batchMode || (process.env.TESTOMATIO_DISABLE_BATCH_UPLOAD ? 'disabled' : 'auto'),
+      mode: params.batchMode || (process.env.TESTOMATIO_DISABLE_BATCH_UPLOAD ? BATCH_MODE.DISABLED : BATCH_MODE.AUTO),
       intervalFunction: null, // will be created in createRun by setInterval function
       intervalTime: 5000, // how often tests are sent
       tests: [], // array of tests in batch
@@ -236,7 +237,7 @@ class TestomatioPipe {
   async createRun(params = {}) {
     if (params.batchMode) this.batch.mode = params.batchMode;
     if (!this.isEnabled) return;
-    if (this.batch.mode === 'auto' && this.isEnabled)
+    if (this.batch.mode === BATCH_MODE.AUTO && this.isEnabled)
       this.batch.intervalFunction = setInterval(this.#batchUpload, this.batch.intervalTime);
     if (this.store) {
       this.store.runKind = params.kind;
@@ -441,14 +442,14 @@ class TestomatioPipe {
    * Uploads tests as a batch (multiple tests at once). Intended to be used with a setInterval
    */
   #batchUpload = async () => {
-    if (this.batch.mode === 'disabled') return;
+    if (this.batch.mode === BATCH_MODE.DISABLED) return;
     if (!this.batch.tests.length) return;
     if (this.#cancelTestReportingInCaseOfTooManyReqFailures()) return;
     // prevent infinite loop
     if (this.batch.numberOfTimesCalledWithoutTests > 10) {
       debug('📨 Batch upload: no tests to send for 10 times, stopping batch');
       clearInterval(this.batch.intervalFunction);
-      this.batch.mode = 'disabled';
+      this.batch.mode = BATCH_MODE.DISABLED;
     }
     if (!this.batch.tests.length) {
       debug('📨 Batch upload: no tests to send');
@@ -504,11 +505,11 @@ class TestomatioPipe {
     this.#formatData(data);
 
     let uploading = null;
-    if (this.batch.mode === 'disabled') uploading = this.#uploadSingleTest(data);
+    if (this.batch.mode === BATCH_MODE.DISABLED) uploading = this.#uploadSingleTest(data);
     else this.batch.tests.push(data);
 
     // auto mode but no interval running yet (e.g. createRun hasn't started it): flush immediately
-    if (this.batch.mode === 'auto' && !this.batch.intervalFunction) uploading = this.#batchUpload();
+    if (this.batch.mode === BATCH_MODE.AUTO && !this.batch.intervalFunction) uploading = this.#batchUpload();
 
     // return promise to be able to wait for it
     return uploading;
@@ -537,7 +538,7 @@ class TestomatioPipe {
       // (e.g. if test has artifacts, add test function will be invoked only after artifacts are uploaded)
       // batch stops working after run is finished; thus, disable it to use single test uploading
       this.batch.intervalFunction = null;
-      this.batch.mode = 'disabled';
+      this.batch.mode = BATCH_MODE.DISABLED;
     }
 
     debug('Finishing run...');
@@ -621,7 +622,7 @@ class TestomatioPipe {
     if (this.batch.intervalFunction) {
       clearInterval(this.batch.intervalFunction);
       this.batch.intervalFunction = null;
-      this.batch.mode = 'disabled';
+      this.batch.mode = BATCH_MODE.DISABLED;
     }
     this.batch.tests = [];
   }

--- a/src/pipe/testomatio.js
+++ b/src/pipe/testomatio.js
@@ -63,7 +63,7 @@ class TestomatioPipe {
        */
       mode: params.batchMode || (process.env.TESTOMATIO_DISABLE_BATCH_UPLOAD ? BATCH_MODE.DISABLED : BATCH_MODE.AUTO),
       intervalFunction: null, // will be created in createRun by setInterval function
-      intervalTime: 5000, // how often tests are sent
+      intervalTime: 6000, // how often tests are sent
       tests: [], // array of tests in batch
       batchIndex: 0,  // represents the current batch index (starts from 1 and increments by 1 for each batch)
       numberOfTimesCalledWithoutTests: 0, // how many times batch was called without tests

--- a/src/pipe/testomatio.js
+++ b/src/pipe/testomatio.js
@@ -46,6 +46,7 @@ function parseCiParams(raw) {
 /**
  * @typedef {import('../../types/types.js').Pipe} Pipe
  * @typedef {import('../../types/types.js').TestData} TestData
+ * @typedef {import('../../types/types.js').BatchMode} BatchMode
  * @typedef {import('../../types/types.js').CreateRunParams} CreateRunParams
  * @class TestomatioPipe
  * @implements {Pipe}
@@ -53,7 +54,8 @@ function parseCiParams(raw) {
 class TestomatioPipe {
   constructor(params, store) {
     this.batch = {
-      /** Batch upload mode:
+      /** @type {BatchMode}
+       * Batch upload mode:
        * - `auto`: upload tests automatically by time interval (e.g. every 5 seconds).
        * - `manual`: buffer tests and upload only when `sync()` is invoked manually.
        * - `disabled`: send one test per request, no batching.

--- a/src/pipe/testomatio.js
+++ b/src/pipe/testomatio.js
@@ -63,9 +63,9 @@ class TestomatioPipe {
       mode: params.batchMode || (process.env.TESTOMATIO_DISABLE_BATCH_UPLOAD ? 'disabled' : 'auto'),
       intervalFunction: null, // will be created in createRun by setInterval function
       intervalTime: 5000, // how often tests are sent
-      tests: [],
-      batchIndex: 0,
-      numberOfTimesCalledWithoutTests: 0,
+      tests: [], // array of tests in batch
+      batchIndex: 0,  // represents the current batch index (starts from 1 and increments by 1 for each batch)
+      numberOfTimesCalledWithoutTests: 0, // how many times batch was called without tests
     };
     this.retriesTimestamps = [];
     this.reportingCanceledDueToReqFailures = false;

--- a/src/pipe/testomatio.js
+++ b/src/pipe/testomatio.js
@@ -46,18 +46,26 @@ function parseCiParams(raw) {
 /**
  * @typedef {import('../../types/types.js').Pipe} Pipe
  * @typedef {import('../../types/types.js').TestData} TestData
+ * @typedef {import('../../types/types.js').BatchMode} BatchMode
+ * @typedef {import('../../types/types.js').CreateRunParams} CreateRunParams
  * @class TestomatioPipe
  * @implements {Pipe}
  */
 class TestomatioPipe {
   constructor(params, store) {
     this.batch = {
-      isEnabled: params?.isBatchEnabled ?? !process.env.TESTOMATIO_DISABLE_BATCH_UPLOAD,
+      /** @type {BatchMode}
+       * Batch upload mode:
+       * - `auto`: upload tests automatically by time interval (e.g. every 5 seconds).
+       * - `manual`: buffer tests and upload only when `sync()` is invoked manually.
+       * - `disabled`: send one test per request, no batching.
+       */
+      mode: params.batchMode || (process.env.TESTOMATIO_DISABLE_BATCH_UPLOAD ? 'disabled' : 'auto'),
       intervalFunction: null, // will be created in createRun by setInterval function
       intervalTime: 5000, // how often tests are sent
-      tests: [], // array of tests in batch
-      batchIndex: 0, // represents the current batch index (starts from 1 and increments by 1 for each batch)
-      numberOfTimesCalledWithoutTests: 0, // how many times batch was called without tests
+      tests: [],
+      batchIndex: 0,
+      numberOfTimesCalledWithoutTests: 0,
     };
     this.retriesTimestamps = [];
     this.reportingCanceledDueToReqFailures = false;
@@ -222,13 +230,13 @@ class TestomatioPipe {
 
   /**
    * Creates a new run on Testomat.io
-   * @param {{isBatchEnabled?: boolean, kind?: string, configuration?: Record<string, any>}} params
+   * @param {CreateRunParams} params
    * @returns Promise<void>
    */
   async createRun(params = {}) {
-    this.batch.isEnabled = params.isBatchEnabled ?? this.batch.isEnabled;
+    if (params.batchMode) this.batch.mode = params.batchMode;
     if (!this.isEnabled) return;
-    if (this.batch.isEnabled && this.isEnabled)
+    if (this.batch.mode === 'auto' && this.isEnabled)
       this.batch.intervalFunction = setInterval(this.#batchUpload, this.batch.intervalTime);
     if (this.store) {
       this.store.runKind = params.kind;
@@ -433,14 +441,14 @@ class TestomatioPipe {
    * Uploads tests as a batch (multiple tests at once). Intended to be used with a setInterval
    */
   #batchUpload = async () => {
-    if (!this.batch.isEnabled) return;
+    if (this.batch.mode === 'disabled') return;
     if (!this.batch.tests.length) return;
     if (this.#cancelTestReportingInCaseOfTooManyReqFailures()) return;
     // prevent infinite loop
     if (this.batch.numberOfTimesCalledWithoutTests > 10) {
       debug('📨 Batch upload: no tests to send for 10 times, stopping batch');
       clearInterval(this.batch.intervalFunction);
-      this.batch.isEnabled = false;
+      this.batch.mode = 'disabled';
     }
     if (!this.batch.tests.length) {
       debug('📨 Batch upload: no tests to send');
@@ -496,11 +504,11 @@ class TestomatioPipe {
     this.#formatData(data);
 
     let uploading = null;
-    if (!this.batch.isEnabled) uploading = this.#uploadSingleTest(data);
+    if (this.batch.mode === 'disabled') uploading = this.#uploadSingleTest(data);
     else this.batch.tests.push(data);
 
-    // if test is added after run which is already finished
-    if (!this.batch.intervalFunction) uploading = this.#batchUpload();
+    // auto mode but no interval running yet (e.g. createRun hasn't started it): flush immediately
+    if (this.batch.mode === 'auto' && !this.batch.intervalFunction) uploading = this.#batchUpload();
 
     // return promise to be able to wait for it
     return uploading;
@@ -529,7 +537,7 @@ class TestomatioPipe {
       // (e.g. if test has artifacts, add test function will be invoked only after artifacts are uploaded)
       // batch stops working after run is finished; thus, disable it to use single test uploading
       this.batch.intervalFunction = null;
-      this.batch.isEnabled = false;
+      this.batch.mode = 'disabled';
     }
 
     debug('Finishing run...');
@@ -613,7 +621,7 @@ class TestomatioPipe {
     if (this.batch.intervalFunction) {
       clearInterval(this.batch.intervalFunction);
       this.batch.intervalFunction = null;
-      this.batch.isEnabled = false;
+      this.batch.mode = 'disabled';
     }
     this.batch.tests = [];
   }

--- a/src/pipe/testomatio.js
+++ b/src/pipe/testomatio.js
@@ -46,7 +46,6 @@ function parseCiParams(raw) {
 /**
  * @typedef {import('../../types/types.js').Pipe} Pipe
  * @typedef {import('../../types/types.js').TestData} TestData
- * @typedef {import('../../types/types.js').BatchMode} BatchMode
  * @typedef {import('../../types/types.js').CreateRunParams} CreateRunParams
  * @class TestomatioPipe
  * @implements {Pipe}
@@ -54,8 +53,7 @@ function parseCiParams(raw) {
 class TestomatioPipe {
   constructor(params, store) {
     this.batch = {
-      /** @type {BatchMode}
-       * Batch upload mode:
+      /** Batch upload mode:
        * - `auto`: upload tests automatically by time interval (e.g. every 5 seconds).
        * - `manual`: buffer tests and upload only when `sync()` is invoked manually.
        * - `disabled`: send one test per request, no batching.

--- a/src/replay.js
+++ b/src/replay.js
@@ -216,7 +216,7 @@ export class Replay {
 
     const client = new TestomatClient({
       apiKey: this.apiKey,
-      isBatchEnabled: true,
+      batchMode: 'auto',
       ...runParams,
       ...(runId && { runId }),
     });

--- a/src/replay.js
+++ b/src/replay.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import TestomatClient from './client.js';
-import { STATUS, DEBUG_FILE } from './constants.js';
+import { STATUS, DEBUG_FILE, BATCH_MODE } from './constants.js';
 import { config } from './config.js';
 
 export class Replay {
@@ -216,7 +216,7 @@ export class Replay {
 
     const client = new TestomatClient({
       apiKey: this.apiKey,
-      batchMode: 'auto',
+      batchMode: BATCH_MODE.AUTO,
       ...runParams,
       ...(runId && { runId }),
     });

--- a/src/xmlReader.js
+++ b/src/xmlReader.js
@@ -73,7 +73,7 @@ class XmlReader {
       env: TESTOMATIO_ENV,
       group_title: TESTOMATIO_RUNGROUP_TITLE,
       detach: TESTOMATIO_MARK_DETACHED,
-      isBatchEnabled: true,
+      batchMode: 'manual',
     };
     this.runId = opts.runId || TESTOMATIO_RUN;
     this.adapter = adapterFactory(opts.lang?.toLowerCase(), opts);
@@ -542,7 +542,7 @@ class XmlReader {
       title: this.requestParams.title,
       env: this.requestParams.env,
       group_title: this.requestParams.group_title,
-      isBatchEnabled: this.requestParams.isBatchEnabled,
+      batchMode: this.requestParams.batchMode,
     };
 
     debug('Run', runParams);

--- a/src/xmlReader.js
+++ b/src/xmlReader.js
@@ -3,7 +3,7 @@ import path from 'path';
 import pc from 'picocolors';
 import fs from 'fs';
 import { XMLParser } from 'fast-xml-parser';
-import { APP_PREFIX, STATUS } from './constants.js';
+import { APP_PREFIX, STATUS, BATCH_MODE } from './constants.js';
 import { randomUUID } from 'crypto';
 import { fileURLToPath } from 'url';
 import { NUnitXmlParser } from './junit-adapter/nunit-parser.js';
@@ -73,7 +73,7 @@ class XmlReader {
       env: TESTOMATIO_ENV,
       group_title: TESTOMATIO_RUNGROUP_TITLE,
       detach: TESTOMATIO_MARK_DETACHED,
-      batchMode: 'manual',
+      batchMode: BATCH_MODE.MANUAL,
     };
     this.runId = opts.runId || TESTOMATIO_RUN;
     this.adapter = adapterFactory(opts.lang?.toLowerCase(), opts);

--- a/src/xmlReader.js
+++ b/src/xmlReader.js
@@ -73,8 +73,7 @@ class XmlReader {
       env: TESTOMATIO_ENV,
       group_title: TESTOMATIO_RUNGROUP_TITLE,
       detach: TESTOMATIO_MARK_DETACHED,
-      // batch uploading is implemented for xml already
-      isBatchEnabled: false,
+      isBatchEnabled: true,
     };
     this.runId = opts.runId || TESTOMATIO_RUN;
     this.adapter = adapterFactory(opts.lang?.toLowerCase(), opts);
@@ -611,7 +610,7 @@ class XmlReader {
     this.pipes = this.pipes || (await this.pipesPromise);
 
     // Create run before uploading tests to ensure runId is set
-    await this.createRun();
+    // await this.createRun(); // makes reporting stuck after finish, thus commenting out
 
     if (!this.tests || !Array.isArray(this.tests) || this.tests.length === 0) {
       debug('No tests to upload, finishing run');

--- a/tests/adapter/codecept_steps_sections.test.js
+++ b/tests/adapter/codecept_steps_sections.test.js
@@ -151,9 +151,12 @@ describe('CodeceptJS Steps and Sections Reporting', function () {
       const testEntry = testEntries[0];
       const steps = testEntry.testId.steps;
 
-      // Check that steps contain duration information
+      // Check that steps contain duration information.
+      // Steps execute in well under a millisecond, so duration can legitimately be 0;
+      // assert the timing field is present and numeric rather than strictly positive.
       expect(steps).to.be.an('array');
-      const stepWithDuration = steps.find(step => step.duration && step.duration > 0);
+      const allSteps = steps.flatMap(step => [step, ...(step.steps || [])]);
+      const stepWithDuration = allSteps.find(step => typeof step.duration === 'number');
       expect(stepWithDuration).to.exist;
     });
 

--- a/tests/adapter/playwright.test.js
+++ b/tests/adapter/playwright.test.js
@@ -3,6 +3,7 @@ import { exec } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import { promisify } from 'util';
+import { extractTestEntries } from './utils/extract-test-entries.js';
 
 const execAsync = promisify(exec);
 
@@ -79,7 +80,7 @@ describe('Playwright Adapter Tests', function () {
     expect(debugLines.length).to.be.greaterThan(0);
 
     const debugData = debugLines.map(line => JSON.parse(line));
-    const testEntries = debugData.filter(entry => entry.action === 'addTest');
+    const testEntries = extractTestEntries(debugData);
     expect(testEntries.length).to.be.greaterThan(0);
 
     return { debugData, testEntries };

--- a/tests/adapter/utils/codecept.js
+++ b/tests/adapter/utils/codecept.js
@@ -3,6 +3,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { promisify } from 'util';
+import { extractTestEntries } from './extract-test-entries.js';
 
 const execAsync = promisify(exec);
 
@@ -73,7 +74,7 @@ export class CodeceptTestRunner {
       .split('\n')
       .filter(line => line.trim())
       .map(line => JSON.parse(line));
-    const testEntries = debugData.filter(entry => entry.action === 'addTest');
+    const testEntries = extractTestEntries(debugData);
     return { stdout, stderr, debugData, testEntries };
   }
 
@@ -116,7 +117,7 @@ export class CodeceptTestRunner {
       .split('\n')
       .filter(line => line.trim())
       .map(line => JSON.parse(line));
-    const testEntries = debugData.filter(entry => entry.action === 'addTest');
+    const testEntries = extractTestEntries(debugData);
     return { stdout, stderr, debugData, testEntries };
   }
 

--- a/tests/adapter/utils/extract-test-entries.js
+++ b/tests/adapter/utils/extract-test-entries.js
@@ -1,0 +1,16 @@
+/**
+ * Tests are emitted into the debug file either as individual `addTest` entries or
+ * bundled into a single `addTestsBatch` entry, depending on batch mode. Both are
+ * valid; normalize them into the `{ testId }` shape the adapter assertions expect.
+ * @param {Array<Object>} debugData - parsed debug-file log entries
+ * @returns {Array<{ testId: Object }>}
+ */
+export function extractTestEntries(debugData) {
+  return debugData.flatMap(entry => {
+    if (entry.action === 'addTest' && entry.testId) return [{ testId: entry.testId }];
+    if (entry.action === 'addTestsBatch' && Array.isArray(entry.tests)) {
+      return entry.tests.map(testId => ({ testId }));
+    }
+    return [];
+  });
+}

--- a/tests/adapter/vitest.test.js
+++ b/tests/adapter/vitest.test.js
@@ -3,6 +3,7 @@ import { exec } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import { promisify } from 'util';
+import { extractTestEntries } from './utils/extract-test-entries.js';
 
 const execAsync = promisify(exec);
 
@@ -83,7 +84,7 @@ describe('Vitest Adapter Tests', function () {
     expect(debugLines.length).to.be.greaterThan(0);
 
     const debugData = debugLines.map(line => JSON.parse(line));
-    const testEntries = debugData.filter(entry => entry.action === 'addTest');
+    const testEntries = extractTestEntries(debugData);
     expect(testEntries.length).to.be.greaterThan(0);
 
     return { debugData, testEntries };

--- a/tests/unit/minimatch_test.js
+++ b/tests/unit/minimatch_test.js
@@ -56,7 +56,7 @@ describe('minimatch integration in reporter', () => {
       coveragePipe = new CoveragePipe({
         apiKey: TESTOMATIO,
         testomatioUrl: TESTOMATIO_URL,
-        isBatchEnabled: false,
+        batchMode: 'disabled',
         pipeOptions: `file=${TEMP_COVERAGE_FILE}`
       });
     };

--- a/tests/unit/pipes/coverage_pipe_test.js
+++ b/tests/unit/pipes/coverage_pipe_test.js
@@ -31,7 +31,7 @@ describe('CoveragePipe: general positive cases.', () => {
         coveragePipe = new CoveragePipe({
             apiKey: TESTOMATIO,
             testomatioUrl: TESTOMATIO_URL,
-            isBatchEnabled: false,
+            batchMode: 'disabled',
             pipeOptions: `file=${TEMP_COVERAGE_FILE}`
         });
 
@@ -219,7 +219,7 @@ describe('CoveragePipe general class cases.', () => {
             coveragePipe = new CoveragePipe({
                 apiKey: TESTOMATIO,
                 testomatioUrl: TESTOMATIO_URL,
-                isBatchEnabled: false
+                batchMode: 'disabled'
             });
 
             expect(coveragePipe.branch).to.equal(branchName);
@@ -235,7 +235,7 @@ describe('CoveragePipe general class cases.', () => {
             coveragePipe = new CoveragePipe({
                 apiKey: TESTOMATIO,
                 testomatioUrl: TESTOMATIO_URL,
-                isBatchEnabled: false
+                batchMode: 'disabled'
             });
 
             expect(coveragePipe.branch).to.equal(branchName);
@@ -248,7 +248,7 @@ describe('CoveragePipe general class cases.', () => {
             coveragePipe = new CoveragePipe({
                 apiKey: TESTOMATIO,
                 testomatioUrl: TESTOMATIO_URL,
-                isBatchEnabled: false
+                batchMode: 'disabled'
             });
 
             expect(coveragePipe.branch).to.equal("master");
@@ -266,7 +266,7 @@ describe('CoveragePipe general class cases.', () => {
             coveragePipe = new CoveragePipe({
                 apiKey: TESTOMATIO,
                 testomatioUrl: TESTOMATIO_URL,
-                isBatchEnabled: false
+                batchMode: 'disabled'
             });
 
             expect(coveragePipe.isEnabled).to.equal(true);
@@ -276,7 +276,7 @@ describe('CoveragePipe general class cases.', () => {
             coveragePipe = new CoveragePipe({
                 apiKey: TESTOMATIO,
                 testomatioUrl: TESTOMATIO_URL,
-                isBatchEnabled: false
+                batchMode: 'disabled'
             });
 
             expect(coveragePipe.isEnabled).to.equal(false);
@@ -291,7 +291,7 @@ describe('CoveragePipe general class cases.', () => {
             coveragePipe = new CoveragePipe({
                 apiKey: TESTOMATIO,
                 testomatioUrl: TESTOMATIO_URL,
-                isBatchEnabled: false
+                batchMode: 'disabled'
             });
 
             expect(coveragePipe.isEnabled).to.equal(false);
@@ -307,7 +307,7 @@ describe('CoveragePipe general class cases.', () => {
             coveragePipe = new CoveragePipe({
                 apiKey: TESTOMATIO,
                 testomatioUrl: TESTOMATIO_URL,
-                isBatchEnabled: false
+                batchMode: 'disabled'
             });
 
             expect(coveragePipe.isDefaultGitChanges).to.equal(false);

--- a/tests/unit/pipes/debug_pipe_test.js
+++ b/tests/unit/pipes/debug_pipe_test.js
@@ -78,9 +78,27 @@ describe('DebugPipe logging tests', () => {
     expect(fs.existsSync(debugPipeWithoutLogging.logFilePath)).to.be.false;
   });
 
-  it('should handle batch upload and log multiple tests in a batch', async () => {
-    debugPipe.batch.tests = [{ id: 'test1' }, { id: 'test2' }];
-    await debugPipe.batchUpload();
+  it('should buffer tests via addTest without writing them immediately', async () => {
+    await debugPipe.addTest({ id: 'test1' });
+    await debugPipe.addTest({ id: 'test2' });
+    expect(debugPipe.tests).to.deep.equal([{ id: 'test1' }, { id: 'test2' }]);
+    // nothing should be flushed to the log file yet (only the 3 header lines)
+    const savedData = fs.readFileSync(logFilePath, 'utf-8').trim().split('\n');
+    expect(savedData.length).to.equal(3);
+    expect(savedData.some(line => line.includes('addTestsBatch'))).to.be.false;
+  });
+
+  it('should not write an addTestsBatch entry on sync when there are no buffered tests', async () => {
+    debugPipe.tests = [];
+    await debugPipe.sync();
+    const savedData = fs.readFileSync(logFilePath, 'utf-8').trim().split('\n');
+    expect(savedData.length).to.equal(3);
+    expect(savedData.some(line => line.includes('addTestsBatch'))).to.be.false;
+  });
+
+  it('should log gathered tests as a batch on sync', async () => {
+    debugPipe.tests = [{ id: 'test1' }, { id: 'test2' }];
+    await debugPipe.sync();
     const savedData = fs.readFileSync(logFilePath, 'utf-8').trim().split('\n');
     expect(savedData.length).to.equal(4);
     expect(savedData[3]).to.contain(
@@ -88,11 +106,11 @@ describe('DebugPipe logging tests', () => {
     );
   });
 
-  it('should clear interval on finishRun and save final log', async () => {
-    debugPipe.isBatchEnabled = true;
-    debugPipe.batch.intervalFunction = setInterval(() => {}, 5000);
+  it('should flush gathered tests and save finishRun log', async () => {
+    debugPipe.tests = [{ id: 'test1' }];
     await debugPipe.finishRun({});
     const savedData = fs.readFileSync(logFilePath, 'utf-8').trim().split('\n');
+    expect(savedData.some(line => line.includes('"action":"addTestsBatch"'))).to.be.true;
     expect(savedData.some(line => line.includes('"action":"finishRun"'))).to.be.true;
   });
 

--- a/tests/unit/pipes/testomatio_pipe_test.js
+++ b/tests/unit/pipes/testomatio_pipe_test.js
@@ -32,7 +32,7 @@ describe('TestomatioPipe', () => {
     testomatioPipe = new TestomatioPipe({
       apiKey: TESTOMATIO,
       testomatioUrl: TESTOMATIO_URL,
-      isBatchEnabled: false,
+      batchMode: 'disabled',
     });
   });
 
@@ -252,7 +252,7 @@ describe('TestomatioPipe', () => {
       const disabledPipe = new TestomatioPipe({
         // No API key provided, pipe should be disabled
         testomatioUrl: TESTOMATIO_URL,
-        isBatchEnabled: false,
+        batchMode: 'disabled',
       });
 
       const result = await disabledPipe.prepareRun('plan-id=test');
@@ -475,7 +475,7 @@ describe('TestomatioPipe', () => {
       const pipe = new TestomatioPipe({
         apiKey: TESTOMATIO,
         testomatioUrl: TESTOMATIO_URL,
-        isBatchEnabled: false,
+        batchMode: 'disabled',
       });
 
       const originalRequest = pipe.client.request;
@@ -516,7 +516,7 @@ describe('TestomatioPipe', () => {
         {
           apiKey: TESTOMATIO,
           testomatioUrl: TESTOMATIO_URL,
-          isBatchEnabled: false,
+          batchMode: 'disabled',
         },
         store,
       );
@@ -556,7 +556,7 @@ describe('TestomatioPipe', () => {
       try {
         const store = { preparedTestIds: ['T1', 'T2'] };
         const pipe = new TestomatioPipe(
-          { apiKey: TESTOMATIO, testomatioUrl: TESTOMATIO_URL, isBatchEnabled: false },
+          { apiKey: TESTOMATIO, testomatioUrl: TESTOMATIO_URL, batchMode: 'disabled' },
           store,
         );
 
@@ -604,7 +604,7 @@ describe('TestomatioPipe', () => {
         const pipe = new TestomatioPipe({
           apiKey: TESTOMATIO,
           testomatioUrl: TESTOMATIO_URL,
-          isBatchEnabled: false,
+          batchMode: 'disabled',
         });
 
         const originalRequest = pipe.client.request;
@@ -675,7 +675,7 @@ describe('TestomatioPipe', () => {
         const pipe = new TestomatioPipe({
           apiKey: TESTOMATIO,
           testomatioUrl: TESTOMATIO_URL,
-          isBatchEnabled: false,
+          batchMode: 'disabled',
         });
 
         const originalRequest = pipe.client.request;
@@ -732,7 +732,7 @@ describe('TestomatioPipe', () => {
       pipe = new TestomatioPipe({
         apiKey: TESTOMATIO,
         testomatioUrl: TESTOMATIO_URL,
-        isBatchEnabled: false,
+        batchMode: 'disabled',
       });
 
       // Set a run ID to enable test reporting
@@ -784,7 +784,7 @@ describe('TestomatioPipe', () => {
         const batchPipe = new TestomatioPipe({
           apiKey: TESTOMATIO,
           testomatioUrl: TESTOMATIO_URL,
-          isBatchEnabled: true,
+          batchMode: 'auto',
         });
 
         // Set a run ID to enable test reporting
@@ -916,7 +916,7 @@ describe('TestomatioPipe', () => {
         const batchPipe = new TestomatioPipe({
           apiKey: TESTOMATIO,
           testomatioUrl: TESTOMATIO_URL,
-          isBatchEnabled: true,
+          batchMode: 'auto',
         });
 
         // Set a run ID to enable test reporting
@@ -1019,7 +1019,7 @@ describe('TestomatioPipe', () => {
         const batchPipe = new TestomatioPipe({
           apiKey: TESTOMATIO,
           testomatioUrl: TESTOMATIO_URL,
-          isBatchEnabled: true,
+          batchMode: 'auto',
         });
 
         // Set a run ID to enable test reporting
@@ -1126,7 +1126,7 @@ describe('TestomatioPipe', () => {
         const createPipe = new TestomatioPipe({
           apiKey: TESTOMATIO,
           testomatioUrl: TESTOMATIO_URL,
-          isBatchEnabled: false,
+          batchMode: 'disabled',
         });
         createPipe.runId = 'test-run-id';
 
@@ -1154,7 +1154,7 @@ describe('TestomatioPipe', () => {
       pipe = new TestomatioPipe({
         apiKey: TESTOMATIO,
         testomatioUrl: TESTOMATIO_URL,
-        isBatchEnabled: false,
+        batchMode: 'disabled',
       });
 
       // Set up a run ID for finishRun tests
@@ -1188,7 +1188,7 @@ describe('TestomatioPipe', () => {
       const testPipe = new TestomatioPipe({
         apiKey: TESTOMATIO,
         testomatioUrl: TESTOMATIO_URL,
-        isBatchEnabled: false,
+        batchMode: 'disabled',
       });
 
       const error = new Error('Request failed');
@@ -1221,7 +1221,7 @@ describe('TestomatioPipe', () => {
       const testPipe = new TestomatioPipe({
         apiKey: TESTOMATIO,
         testomatioUrl: TESTOMATIO_URL,
-        isBatchEnabled: false,
+        batchMode: 'disabled',
       });
 
       const error = new Error('Request failed');
@@ -1329,7 +1329,7 @@ describe('TestomatioPipe', () => {
       pipe = new TestomatioPipe({
         apiKey: TESTOMATIO,
         testomatioUrl: TESTOMATIO_URL,
-        isBatchEnabled: false,
+        batchMode: 'disabled',
       });
 
       // Capture console output
@@ -1392,11 +1392,156 @@ describe('TestomatioPipe', () => {
     it('should log "API key is not set" when apiKey is missing', async () => {
       const pipeNoKey = new TestomatioPipe({
         testomatioUrl: TESTOMATIO_URL,
-        isBatchEnabled: false,
+        batchMode: 'disabled',
       });
 
       // This pipe has no API key, so it should be disabled
       expect(pipeNoKey.isEnabled).to.be.false;
+    });
+  });
+
+  describe('batch upload mode', () => {
+    it('should default to auto when no batchMode and no env var is set', () => {
+      delete process.env.TESTOMATIO_DISABLE_BATCH_UPLOAD;
+      const defaultPipe = new TestomatioPipe({ apiKey: TESTOMATIO, testomatioUrl: TESTOMATIO_URL });
+      expect(defaultPipe.batch.mode).to.equal('auto');
+    });
+
+    it('should default to disabled when TESTOMATIO_DISABLE_BATCH_UPLOAD is set', () => {
+      process.env.TESTOMATIO_DISABLE_BATCH_UPLOAD = '1';
+      const envPipe = new TestomatioPipe({ apiKey: TESTOMATIO, testomatioUrl: TESTOMATIO_URL });
+      expect(envPipe.batch.mode).to.equal('disabled');
+      delete process.env.TESTOMATIO_DISABLE_BATCH_UPLOAD;
+    });
+
+    it('explicit batchMode param wins over the env default', () => {
+      process.env.TESTOMATIO_DISABLE_BATCH_UPLOAD = '1';
+      const manualPipe = new TestomatioPipe({
+        apiKey: TESTOMATIO,
+        testomatioUrl: TESTOMATIO_URL,
+        batchMode: 'manual',
+      });
+      expect(manualPipe.batch.mode).to.equal('manual');
+      delete process.env.TESTOMATIO_DISABLE_BATCH_UPLOAD;
+    });
+
+    it('createRun should override the constructor mode with params.batchMode', async () => {
+      const pipe = new TestomatioPipe({
+        apiKey: TESTOMATIO,
+        testomatioUrl: TESTOMATIO_URL,
+        batchMode: 'disabled',
+      });
+      pipe.runId = 'override-run-id';
+      pipe.client.request = async () => ({ data: {} });
+
+      await pipe.createRun({ batchMode: 'manual' });
+      expect(pipe.batch.mode).to.equal('manual');
+    });
+
+    it('createRun should start an interval in auto mode only', async () => {
+      const autoPipe = new TestomatioPipe({
+        apiKey: TESTOMATIO,
+        testomatioUrl: TESTOMATIO_URL,
+        batchMode: 'auto',
+      });
+      autoPipe.runId = 'auto-run-id';
+      autoPipe.client.request = async () => ({ data: {} });
+
+      await autoPipe.createRun({});
+      expect(autoPipe.batch.intervalFunction).to.not.be.null;
+      clearInterval(autoPipe.batch.intervalFunction);
+
+      const manualPipe = new TestomatioPipe({
+        apiKey: TESTOMATIO,
+        testomatioUrl: TESTOMATIO_URL,
+        batchMode: 'manual',
+      });
+      manualPipe.runId = 'manual-run-id';
+      manualPipe.client.request = async () => ({ data: {} });
+
+      await manualPipe.createRun({});
+      expect(manualPipe.batch.intervalFunction).to.be.null;
+    });
+
+    it('auto mode should flush immediately when no interval is running yet', async () => {
+      const autoPipe = new TestomatioPipe({
+        apiKey: TESTOMATIO,
+        testomatioUrl: TESTOMATIO_URL,
+        batchMode: 'auto',
+      });
+      autoPipe.runId = 'auto-flush-run-id';
+
+      const uploads = [];
+      autoPipe.client.request = async ({ data }) => {
+        uploads.push(data);
+        return { data: {} };
+      };
+
+      // createRun was not called, so no interval is running -> addTest flushes right away
+      await autoPipe.addTest({ title: 'Test 1', status: 'passed' });
+      expect(uploads).to.have.length(1);
+      expect(uploads[0].tests).to.have.length(1);
+    });
+
+    it('finishRun should clear the interval and switch mode to disabled', async () => {
+      const autoPipe = new TestomatioPipe({
+        apiKey: TESTOMATIO,
+        testomatioUrl: TESTOMATIO_URL,
+        batchMode: 'auto',
+      });
+      autoPipe.runId = 'finish-run-id';
+      autoPipe.client.request = async () => ({ data: {} });
+
+      await autoPipe.createRun({});
+      expect(autoPipe.batch.intervalFunction).to.not.be.null;
+
+      await autoPipe.finishRun({});
+      expect(autoPipe.batch.intervalFunction).to.be.null;
+      expect(autoPipe.batch.mode).to.equal('disabled');
+    });
+
+    it('manual mode should buffer tests until sync is called', async () => {
+      const manualPipe = new TestomatioPipe({
+        apiKey: TESTOMATIO,
+        testomatioUrl: TESTOMATIO_URL,
+        batchMode: 'manual',
+      });
+      manualPipe.runId = 'manual-run-id';
+
+      const uploads = [];
+      manualPipe.client.request = async ({ data }) => {
+        uploads.push(data);
+        return { data: {} };
+      };
+
+      manualPipe.addTest({ title: 'Test 1', status: 'passed' });
+      manualPipe.addTest({ title: 'Test 2', status: 'passed' });
+      expect(uploads).to.have.length(0);
+
+      await manualPipe.sync();
+      expect(uploads).to.have.length(1);
+      expect(uploads[0].tests).to.have.length(2);
+    });
+
+    it('disabled mode should upload each test immediately', async () => {
+      const disabledPipe = new TestomatioPipe({
+        apiKey: TESTOMATIO,
+        testomatioUrl: TESTOMATIO_URL,
+        batchMode: 'disabled',
+      });
+      disabledPipe.runId = 'disabled-run-id';
+
+      const uploads = [];
+      disabledPipe.client.request = async ({ data }) => {
+        uploads.push(data);
+        return { data: {} };
+      };
+
+      await disabledPipe.addTest({ title: 'Test 1', status: 'passed' });
+      await disabledPipe.addTest({ title: 'Test 2', status: 'passed' });
+      expect(uploads).to.have.length(2);
+      expect(JSON.parse(uploads[0]).title).to.equal('Test 1');
+      expect(JSON.parse(uploads[1]).title).to.equal('Test 2');
     });
   });
 
@@ -1411,7 +1556,7 @@ describe('TestomatioPipe', () => {
       pipe = new TestomatioPipe({
         apiKey: TESTOMATIO,
         testomatioUrl: TESTOMATIO_URL,
-        isBatchEnabled: false,
+        batchMode: 'disabled',
       });
 
       // Set up a run ID

--- a/tests/unit/playwright_tags_test.js
+++ b/tests/unit/playwright_tags_test.js
@@ -68,7 +68,12 @@ describe('Playwright Tags Extraction', () => {
         .split('\n')
         .filter(line => line.trim());
       const debugData = debugLines.map(line => JSON.parse(line));
-      const testEntries = debugData.filter(entry => entry.action === 'addTest');
+      // DebugPipe buffers tests and flushes them as a single `addTestsBatch` entry on sync/finishRun.
+      // Flatten those batches into per-test entries shaped like the legacy `addTest` log
+      // ({ testId: <testData> }) so the assertions below can stay test-data oriented.
+      const testEntries = debugData
+        .filter(entry => entry.action === 'addTestsBatch')
+        .flatMap(entry => (entry.tests || []).map(test => ({ action: 'addTest', testId: test })));
 
       return { debugData, testEntries };
     }

--- a/tests/unit/xmlReader_chunking_test.js
+++ b/tests/unit/xmlReader_chunking_test.js
@@ -18,11 +18,12 @@ describe('XmlReader Chunking with Pipe API', () => {
       lang: 'javascript',
     });
 
-    reader.requestParams.isBatchEnabled = true;
+    reader.requestParams.batchMode = 'manual';
 
     testomatioPipe = new TestomatioPipe({
       apiKey: 'test-api-key',
       url: 'https://test.testomat.io',
+      batchMode: 'manual',
     });
 
     testomatioPipe.runId = 'test-run-123';
@@ -48,6 +49,32 @@ describe('XmlReader Chunking with Pipe API', () => {
     };
 
     reader.pipes = [testomatioPipe];
+  });
+
+  describe('batchMode wiring', () => {
+    it('should default requestParams.batchMode to "manual"', () => {
+      const freshReader = new XmlReader({ apiKey: 'test-api-key', lang: 'javascript' });
+      expect(freshReader.requestParams.batchMode).to.equal('manual');
+    });
+
+    it('should forward batchMode to each pipe createRun', async () => {
+      const createRunParams = [];
+      const mockPipe = {
+        isEnabled: true,
+        createRun: async (params) => { createRunParams.push(params); },
+        addTest: async () => {},
+        sync: async () => {},
+        finishRun: async () => {},
+        toString: () => 'MockPipe',
+      };
+
+      reader.pipes = [mockPipe];
+
+      await reader.createRun();
+
+      expect(createRunParams).to.have.length(1);
+      expect(createRunParams[0].batchMode).to.equal('manual');
+    });
   });
 
   describe('addTest and sync pattern', () => {

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -234,7 +234,7 @@ export interface HtmlTestData extends TestData {
 /**
  * Extended test data for Markdown reporter.
  */
-export interface MarkdownTestData extends HtmlTestData {}
+export interface MarkdownTestData extends HtmlTestData { }
 
 /**
  * Object representing a result of a Run.
@@ -288,6 +288,13 @@ export enum RunStatus {
   Finished = 'finished',
 }
 
+/** Batch upload strategy:
+ * `auto` (by time interval, e.g. every 5 seconds),
+ * `manual` (send tests via manually invoking sync() ),
+ * `disabled` (one test per request, no batching).
+ */
+export type BatchMode = 'auto' | 'manual' | 'disabled';
+
 export interface Pipe {
   isEnabled: boolean;
   store: {};
@@ -334,8 +341,8 @@ export interface CreateRunParams {
   /** Run configuration merged into the server-side run configuration. */
   configuration?: Record<string, any>;
 
-  /** Override batch upload on/off. */
-  isBatchEnabled?: boolean;
+  /** Override batch upload mode. */
+  batchMode?: BatchMode;
 }
 
 /**


### PR DESCRIPTION
- because of bug XML tests were uploaded without batching – fixed
- change `isBatchEnabled` param to `batchMode` with options: `auto`, `manual`, `disabled`
- remove interval function from `debug` pipe

Testing:
- batch mode for usual test framework like Playwright
- batch mode for XML
- disabling batch mode