### PR TITLE
Fix playwright artifacts uploaded twice

### DIFF
--- a/src/adapter/playwright.js
+++ b/src/adapter/playwright.js
@@ -126,7 +126,7 @@ class PlaywrightReporter {
       logs,
       links,
       manuallyAttachedArtifacts,
-      files: files.length ? files : undefined,
+      // files are uploaded in onEnd to avoid duplicate uploads
       meta: {
         browser: project.browser,
         isMobile: project.isMobile,

--- a/src/adapter/playwright.js
+++ b/src/adapter/playwright.js
@@ -48,14 +48,8 @@ class PlaywrightReporter {
     const { title } = test;
     const { error, duration } = result;
     const pwAttachments = (result.attachments || []).filter(a => a.body || a.path);
-
-    const files = pwAttachments
-      .map(att => ({
-        path: this.#getArtifactPath(att),
-        title: att.name || title,
-        type: att.contentType,
-      }))
-      .filter(f => f.path);
+    const files = buildArtifactFiles(pwAttachments, attachment => this.#getArtifactPath(attachment), title);
+    const artifactsForUpload = processArtifactsForUpload(pwAttachments);
 
     const suite_title = test.parent ? test.parent?.title : path.basename(test?.location?.file);
 
@@ -126,7 +120,7 @@ class PlaywrightReporter {
       logs,
       links,
       manuallyAttachedArtifacts,
-      // files are uploaded in onEnd to avoid duplicate uploads
+      files: files.length ? files : undefined,
       meta: {
         browser: project.browser,
         isMobile: project.isMobile,
@@ -150,7 +144,7 @@ class PlaywrightReporter {
     this.uploads.push({
       rid: `${rid}-${project.name}`,
       title: test.title,
-      files: pwAttachments,
+      files: artifactsForUpload,
       file: test.location?.file,
     });
     // remove empty uploads
@@ -227,6 +221,25 @@ function checkStatus(status) {
       passed: Status.PASSED,
     }[status] || Status.FAILED
   );
+}
+
+function buildArtifactFiles(attachments, getArtifactPath, title) {
+  return attachments
+    .filter(isScreenshotArtifact)
+    .map(attachment => ({
+      path: getArtifactPath(attachment),
+      title: attachment.name || title,
+      type: attachment.contentType,
+    }))
+    .filter(file => file.path);
+}
+
+function processArtifactsForUpload(attachments) {
+  return attachments.filter(attachment => !isScreenshotArtifact(attachment));
+}
+
+function isScreenshotArtifact(attachment) {
+  return attachment?.contentType === 'image/png' && attachment?.name === 'screenshot';
 }
 
 function appendStep(step, shift = 0) {

--- a/tests/unit/playwright_reporter_fast_artifacts_test.js
+++ b/tests/unit/playwright_reporter_fast_artifacts_test.js
@@ -20,6 +20,8 @@ describe('PlaywrightReporter fast artifacts', () => {
         if (!runCreated) throw new Error('addTestRun was called before createRun completed');
         addTestRunCalls.push({ status, data });
       },
+      uploader: { isEnabled: true },
+      updateRunStatus: async () => {},
     };
 
     reporter.onBegin({ outputDir: '', projects: [{ outputDir: '' }] }, {});
@@ -65,6 +67,12 @@ describe('PlaywrightReporter fast artifacts', () => {
     await testEndPromise;
 
     expect(addTestRunCalls).to.have.length(1);
-    expect(addTestRunCalls[0].data.files).to.have.length(1);
+    expect(addTestRunCalls[0].data.files).to.be.undefined;
+
+    await reporter.onEnd({ status: 'passed' });
+
+    expect(addTestRunCalls).to.have.length(2);
+    expect(addTestRunCalls[1].data.files).to.have.length(1);
+    expect(addTestRunCalls[1].data.files[0].type).to.equal('image/png');
   });
 });

--- a/tests/unit/playwright_reporter_fast_artifacts_test.js
+++ b/tests/unit/playwright_reporter_fast_artifacts_test.js
@@ -51,6 +51,11 @@ describe('PlaywrightReporter fast artifacts', () => {
             contentType: 'image/png',
             name: 'screenshot',
           },
+          {
+            body: Buffer.from('video'),
+            contentType: 'video/webm',
+            name: 'video',
+          },
         ],
         duration: 10,
         status: 'passed',
@@ -67,12 +72,15 @@ describe('PlaywrightReporter fast artifacts', () => {
     await testEndPromise;
 
     expect(addTestRunCalls).to.have.length(1);
-    expect(addTestRunCalls[0].data.files).to.be.undefined;
+    expect(addTestRunCalls[0].data.files).to.have.length(1);
+    expect(addTestRunCalls[0].data.files[0].title).to.equal('screenshot');
+    expect(addTestRunCalls[0].data.files[0].type).to.equal('image/png');
 
     await reporter.onEnd({ status: 'passed' });
 
     expect(addTestRunCalls).to.have.length(2);
     expect(addTestRunCalls[1].data.files).to.have.length(1);
-    expect(addTestRunCalls[1].data.files[0].type).to.equal('image/png');
+    expect(addTestRunCalls[1].data.files[0].title).to.equal('fast test with artifact');
+    expect(addTestRunCalls[1].data.files[0].type).to.equal('video/webm');
   });
 });


### PR DESCRIPTION
### Summary
  - Removed files parameter from addTestRun call in onTestEnd
  - Files now uploaded only once in onEnd