### PR TITLE
add portable local artifacts for HTML report

### DIFF
--- a/docs/pipes/html.md
+++ b/docs/pipes/html.md
@@ -17,6 +17,7 @@ To enable HTML reports, set the TESTOMATIO_HTML_REPORT_SAVE environment variable
 - TESTOMATIO_HTML_REPORT_SAVE=1
 - TESTOMATIO_HTML_REPORT_FOLDER: Specify the folder for HTML reports
 - TESTOMATIO_HTML_FILENAME: Set the desired filename for the HTML report
+- TESTOMATIO_HTML_REPORT_COPY_ARTIFACTS=1: Copy local artifacts, such as screenshots, into the HTML report folder and rewrite their links to relative paths
 
 _!!!Please note that the name must include the extension ".html". If the extension is missing, the report will be saved with the default name = testomatio-report.html_
 
@@ -34,7 +35,22 @@ If a run-level description is provided (e.g. by the Coverage pipe via `coverageD
 
 If `client.createRun({ configuration: { ... } })` is called with a key/value object, the report renders it as a Configuration table beneath the description.
 
+### Portable Local Artifacts
+
+By default, local artifact links keep their original file URLs. This preserves the existing behavior for users who open the generated report on the same machine where tests were executed.
+
+For CI artifact viewers, such as Jenkins, local file URLs can be inaccessible after the report is published. Enable `TESTOMATIO_HTML_REPORT_COPY_ARTIFACTS=1` to make the report folder portable. In this mode, local artifacts are copied to an `artifacts/` folder next to the HTML report, and the report references them with relative links such as `./artifacts/failure.png`.
+
+When this option is enabled, archive or publish the whole report folder, for example `html-report/**`, not only the `.html` file.
+
 #### Example Command
+
+Generate a portable HTML report for Jenkins or another CI artifact viewer:
+
+```
+TESTOMATIO_HTML_REPORT_SAVE=1 TESTOMATIO_HTML_REPORT_COPY_ARTIFACTS=1 TESTOMATIO={API_KEY} npx codeceptjs run
+
+```
 
 📊 Generate a report without triggering the TESTOMATIO pipe (no data sent to the client)
 

--- a/docs/pipes/html.md
+++ b/docs/pipes/html.md
@@ -17,7 +17,7 @@ To enable HTML reports, set the TESTOMATIO_HTML_REPORT_SAVE environment variable
 - TESTOMATIO_HTML_REPORT_SAVE=1
 - TESTOMATIO_HTML_REPORT_FOLDER: Specify the folder for HTML reports
 - TESTOMATIO_HTML_FILENAME: Set the desired filename for the HTML report
-- TESTOMATIO_HTML_REPORT_COPY_ARTIFACTS=1: Copy local artifacts, such as screenshots, into the HTML report folder and rewrite their links to relative paths
+- TESTOMATIO_HTML_REPORT_COPY_ARTIFACTS=0|1: Override automatic local artifact handling
 
 _!!!Please note that the name must include the extension ".html". If the extension is missing, the report will be saved with the default name = testomatio-report.html_
 
@@ -37,18 +37,20 @@ If `client.createRun({ configuration: { ... } })` is called with a key/value obj
 
 ### Portable Local Artifacts
 
-By default, local artifact links keep their original file URLs. This preserves the existing behavior for users who open the generated report on the same machine where tests were executed.
+When S3 artifact uploading is not configured, local artifacts such as screenshots are copied to an `artifacts/` folder next to the HTML report, and the report references them with relative links such as `./artifacts/failure.png`.
 
-For CI artifact viewers, such as Jenkins, local file URLs can be inaccessible after the report is published. Enable `TESTOMATIO_HTML_REPORT_COPY_ARTIFACTS=1` to make the report folder portable. In this mode, local artifacts are copied to an `artifacts/` folder next to the HTML report, and the report references them with relative links such as `./artifacts/failure.png`.
+This makes the report folder portable for CI artifact viewers, such as Jenkins, where `file://` links are inaccessible after the report is published. When S3 artifact uploading is configured, the HTML report keeps local file URLs by default because artifacts are expected to be uploaded separately.
 
-When this option is enabled, archive or publish the whole report folder, for example `html-report/**`, not only the `.html` file.
+Set `TESTOMATIO_HTML_REPORT_COPY_ARTIFACTS=1` to force portable local links even when S3 is configured. Set `TESTOMATIO_HTML_REPORT_COPY_ARTIFACTS=0` to keep original local file URLs.
+
+When portable local links are used, archive or publish the whole report folder, for example `html-report/**`, not only the `.html` file.
 
 #### Example Command
 
 Generate a portable HTML report for Jenkins or another CI artifact viewer:
 
 ```
-TESTOMATIO_HTML_REPORT_SAVE=1 TESTOMATIO_HTML_REPORT_COPY_ARTIFACTS=1 TESTOMATIO={API_KEY} npx codeceptjs run
+TESTOMATIO_HTML_REPORT_SAVE=1 TESTOMATIO={API_KEY} npx codeceptjs run
 
 ```
 

--- a/src/pipe/html.js
+++ b/src/pipe/html.js
@@ -6,11 +6,12 @@ import pc from 'picocolors';
 import handlebars from 'handlebars';
 import { marked } from 'marked';
 import fileUrl from 'file-url';
-import { fileSystem, isSameTest, ansiRegExp, formatStep } from '../utils/utils.js';
+import { fileSystem, isSameTest, ansiRegExp, formatStep, transformEnvVarToBoolean } from '../utils/utils.js';
 import { HTML_REPORT } from '../constants.js';
 import { fileURLToPath } from 'node:url';
 
 const debug = createDebugMessages('@testomatio/reporter:pipe:html');
+const HTML_ARTIFACTS_DIR = 'artifacts';
 
 // @ts-ignore – this line will be removed in compiled code (already defined in the global scope of commonjs)
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -22,6 +23,8 @@ class HtmlPipe {
     this.description = params.description || process.env.TESTOMATIO_DESCRIPTION;
     this.apiKey = params.apiKey || process.env.TESTOMATIO;
     this.isHtml = params.html ?? process.env.TESTOMATIO_HTML_REPORT_SAVE;
+    this.htmlCopyArtifacts =
+      params.htmlCopyArtifacts ?? transformEnvVarToBoolean(process.env.TESTOMATIO_HTML_REPORT_COPY_ARTIFACTS);
 
     debug('HTML Pipe: ', this.apiKey ? 'API KEY' : '*no api key provided*');
 
@@ -151,6 +154,7 @@ class HtmlPipe {
 
     const aggregatedTests = aggregateTestRetries(tests);
 
+    const portableArtifacts = new Map();
     aggregatedTests.forEach(test => {
       const logsRaw =
         test.logs || test.meta?.logs || test.meta?.console || test.meta?.stdout || test.meta?.stderr || '';
@@ -229,6 +233,9 @@ class HtmlPipe {
       }
 
       test.artifacts = normalizeArtifacts(test);
+      if (this.htmlCopyArtifacts) {
+        makeLocalArtifactsPortable(test, outputPath, portableArtifacts);
+      }
 
       const allPossibleArtifacts = [
         ...(test.artifacts || []),
@@ -1013,57 +1020,7 @@ function normalizeArtifacts(test) {
   ];
 
   return allArtifacts
-    .map(artifact => {
-      if (typeof artifact === 'string') {
-        if (/^https?:\/\//i.test(artifact)) {
-          const base = path.basename(new URL(artifact).pathname) || artifact;
-
-          return {
-            name: base,
-            title: base,
-            path: artifact,
-            fsPath: null,
-            relativePath: artifact,
-          };
-        }
-
-        const abs = path.isAbsolute(artifact) ? artifact : path.resolve(process.cwd(), artifact);
-        const href = artifact.startsWith('file://') ? artifact : fileUrl(abs, { resolve: true });
-        const base = path.basename(abs);
-
-        return {
-          name: base,
-          title: base,
-          path: href,
-          fsPath: abs,
-          relativePath: artifact,
-        };
-      }
-
-      if (artifact?.path) {
-        const raw = String(artifact.path);
-        const isFileUrl = raw.startsWith('file://');
-        const isHttpUrl = /^https?:\/\//i.test(raw);
-        const abs = isFileUrl || isHttpUrl ? null : path.isAbsolute(raw) ? raw : path.resolve(process.cwd(), raw);
-        const href = isFileUrl || isHttpUrl ? raw : fileUrl(abs, { resolve: true });
-        const base = abs
-          ? path.basename(abs)
-          : isHttpUrl
-            ? path.basename(new URL(raw).pathname) || artifact.name || artifact.title || 'attachment'
-            : artifact.name || artifact.title || 'attachment';
-
-        return {
-          ...artifact,
-          name: artifact.name || artifact.title || base,
-          title: artifact.title || artifact.name || base,
-          path: href,
-          fsPath: abs || artifact.fsPath || null,
-          relativePath: artifact.relativePath || raw,
-        };
-      }
-
-      return artifact;
-    })
+    .map(normalizeArtifact)
     .filter(Boolean)
     .filter(artifact => {
       const isTrace = (artifact.title === 'trace' || artifact.name === 'trace') &&
@@ -1072,6 +1029,139 @@ function normalizeArtifacts(test) {
         artifact.relativePath?.endsWith('.zip'));
       return !isTrace;
     });
+}
+
+function normalizeArtifact(artifact) {
+  if (typeof artifact === 'string') {
+    return normalizeArtifactPath({ raw: artifact });
+  }
+
+  if (artifact?.path) {
+    return normalizeArtifactPath({
+      raw: String(artifact.path),
+      artifact,
+    });
+  }
+
+  return artifact;
+}
+
+/**
+ * @param {{
+ *   raw: string,
+ *   artifact?: { name?: string, title?: string, relativePath?: string, [key: string]: any }
+ * }} params
+ */
+function normalizeArtifactPath({ raw, artifact = {} }) {
+  const url = parseUrl(raw);
+  const fsPath = getLocalArtifactPath(raw, url);
+  const base = getArtifactBaseName({ raw, url, fsPath, artifact });
+  const href = fsPath && url?.protocol !== 'file:' ? fileUrl(fsPath, { resolve: true }) : raw;
+
+  return {
+    ...artifact,
+    name: artifact.name || artifact.title || base,
+    title: artifact.title || artifact.name || base,
+    path: href,
+    fsPath,
+    relativePath: artifact.relativePath || raw,
+  };
+}
+
+function makeLocalArtifactsPortable(test, outputPath, portableArtifacts) {
+  const reportDir = path.dirname(path.resolve(outputPath));
+
+  test.artifacts = makeArtifactsPortable(test.artifacts, reportDir, portableArtifacts);
+
+  if (Array.isArray(test.stepsArray)) {
+    makeStepArtifactsPortable(test.stepsArray, reportDir, portableArtifacts);
+  }
+}
+
+function makeStepArtifactsPortable(steps, reportDir, portableArtifacts) {
+  steps.forEach(step => {
+    if (Array.isArray(step.artifacts)) {
+      const normalizedArtifacts = step.artifacts.map(normalizeArtifact).filter(Boolean);
+      step.artifacts = makeArtifactsPortable(normalizedArtifacts, reportDir, portableArtifacts);
+    }
+
+    if (Array.isArray(step.steps)) {
+      makeStepArtifactsPortable(step.steps, reportDir, portableArtifacts);
+    }
+  });
+}
+
+function makeArtifactsPortable(artifacts, reportDir, portableArtifacts) {
+  if (!Array.isArray(artifacts)) return artifacts;
+
+  return artifacts.map(artifact => {
+    const fsPath = artifact?.fsPath;
+    if (!fsPath || !fs.existsSync(fsPath)) return artifact;
+
+    const relativePath = copyArtifactToReport(fsPath, reportDir, portableArtifacts);
+    return { ...artifact, path: relativePath, relativePath };
+  });
+}
+
+function copyArtifactToReport(fsPath, reportDir, portableArtifacts) {
+  const absoluteSource = path.resolve(fsPath);
+  if (portableArtifacts.has(absoluteSource)) return portableArtifacts.get(absoluteSource);
+
+  const artifactsDir = path.join(reportDir, HTML_ARTIFACTS_DIR);
+  const ext = path.extname(absoluteSource);
+  const baseName = path.basename(absoluteSource, ext) || 'attachment';
+  let destinationPath = path.join(artifactsDir, `${baseName}${ext}`);
+  let index = 1;
+
+  while (Array.from(portableArtifacts.values()).includes(getRelativeArtifactPath(reportDir, destinationPath))) {
+    destinationPath = path.join(artifactsDir, `${baseName}-${index}${ext}`);
+    index += 1;
+  }
+
+  fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+  fs.copyFileSync(absoluteSource, destinationPath);
+
+  const relativePath = getRelativeArtifactPath(reportDir, destinationPath);
+  portableArtifacts.set(absoluteSource, relativePath);
+  return relativePath;
+}
+
+function getLocalArtifactPath(raw, url = parseUrl(raw)) {
+  if (path.isAbsolute(raw)) return raw;
+  if (isRemoteUrl(url)) return null;
+
+  if (url?.protocol === 'file:') {
+    try {
+      return fileURLToPath(url);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  if (url) return null;
+  return path.resolve(process.cwd(), raw);
+}
+
+function getArtifactBaseName({ raw, url, fsPath, artifact }) {
+  if (fsPath) return path.basename(fsPath);
+  if (url?.pathname) return path.basename(url.pathname) || artifact.name || artifact.title || 'attachment';
+  return artifact.name || artifact.title || path.basename(raw) || 'attachment';
+}
+
+function parseUrl(value) {
+  try {
+    return new URL(String(value));
+  } catch (_) {
+    return null;
+  }
+}
+
+function isRemoteUrl(url) {
+  return url?.protocol === 'http:' || url?.protocol === 'https:';
+}
+
+function getRelativeArtifactPath(reportDir, artifactPath) {
+  return `./${String(path.relative(reportDir, artifactPath)).split(path.sep).join('/')}`;
 }
 
 /**

--- a/src/pipe/html.js
+++ b/src/pipe/html.js
@@ -23,8 +23,7 @@ class HtmlPipe {
     this.description = params.description || process.env.TESTOMATIO_DESCRIPTION;
     this.apiKey = params.apiKey || process.env.TESTOMATIO;
     this.isHtml = params.html ?? process.env.TESTOMATIO_HTML_REPORT_SAVE;
-    this.htmlCopyArtifacts =
-      params.htmlCopyArtifacts ?? transformEnvVarToBoolean(process.env.TESTOMATIO_HTML_REPORT_COPY_ARTIFACTS);
+    this.htmlCopyArtifacts = params.htmlCopyArtifacts;
 
     debug('HTML Pipe: ', this.apiKey ? 'API KEY' : '*no api key provided*');
 
@@ -154,6 +153,7 @@ class HtmlPipe {
 
     const aggregatedTests = aggregateTestRetries(tests);
 
+    const copyLocalArtifacts = resolveHtmlCopyArtifacts(this.htmlCopyArtifacts);
     const portableArtifacts = new Map();
     aggregatedTests.forEach(test => {
       const logsRaw =
@@ -233,7 +233,7 @@ class HtmlPipe {
       }
 
       test.artifacts = normalizeArtifacts(test);
-      if (this.htmlCopyArtifacts) {
+      if (copyLocalArtifacts) {
         makeLocalArtifactsPortable(test, outputPath, portableArtifacts);
       }
 
@@ -1029,6 +1029,18 @@ function normalizeArtifacts(test) {
         artifact.relativePath?.endsWith('.zip'));
       return !isTrace;
     });
+}
+
+function resolveHtmlCopyArtifacts(value) {
+  if (value !== undefined) return transformEnvVarToBoolean(value);
+  if (process.env.TESTOMATIO_HTML_REPORT_COPY_ARTIFACTS !== undefined) {
+    return transformEnvVarToBoolean(process.env.TESTOMATIO_HTML_REPORT_COPY_ARTIFACTS);
+  }
+  return !isS3ArtifactsUploadEnabled();
+}
+
+function isS3ArtifactsUploadEnabled() {
+  return Boolean(process.env.S3_BUCKET && !transformEnvVarToBoolean(process.env.TESTOMATIO_DISABLE_ARTIFACTS));
 }
 
 function normalizeArtifact(artifact) {

--- a/tests/unit/pipes/html_pipe_test.js
+++ b/tests/unit/pipes/html_pipe_test.js
@@ -461,6 +461,111 @@ describe('HTML report tests', () => {
     expect(htmlContent).to.not.include('file:///D:/testomat/reporter/https:/example-bucket.r2.cloudflarestorage.com');
   });
 
+  it('keeps local artifact file URLs by default', () => {
+    process.env.TESTOMATIO_HTML_REPORT_SAVE = '1';
+
+    const template = path.resolve(dirname, '../../..', 'src', 'template', 'testomatio.hbs');
+    const out = path.resolve(testOutputDir, 'with-default-local-artifact.html');
+    const artifactPath = path.resolve(testOutputDir, 'default-local-screenshot.png');
+    fs.writeFileSync(artifactPath, 'fake image');
+
+    const pipe = new HtmlPipe({}, {});
+    pipe.buildReport({
+      runParams: { status: 'failed' },
+      tests: [
+        {
+          title: 'failed with default screenshot behavior',
+          suite_title: 'suite',
+          status: 'failed',
+          message: 'failure',
+          artifacts: [artifactPath],
+        },
+      ],
+      outputPath: out,
+      templatePath: template,
+      warningMsg: '',
+    });
+
+    const copiedArtifact = path.join(testOutputDir, 'artifacts', 'default-local-screenshot.png');
+    const html = fs.readFileSync(out, 'utf-8');
+
+    expect(fs.existsSync(copiedArtifact)).to.equal(false);
+    expect(html).to.include(`file:///${artifactPath.replace(/\\/g, '/')}`);
+    expect(html).to.not.include('./artifacts/default-local-screenshot.png');
+  });
+
+  it('copies local test artifacts next to HTML report and rewrites links to relative paths', () => {
+    process.env.TESTOMATIO_HTML_REPORT_SAVE = '1';
+
+    const template = path.resolve(dirname, '../../..', 'src', 'template', 'testomatio.hbs');
+    const out = path.resolve(testOutputDir, 'with-local-artifact.html');
+    const artifactPath = path.resolve(testOutputDir, 'failed screenshot.png');
+    fs.writeFileSync(artifactPath, 'fake image');
+
+    const pipe = new HtmlPipe({ htmlCopyArtifacts: true }, {});
+    pipe.buildReport({
+      runParams: { status: 'failed' },
+      tests: [
+        {
+          title: 'failed with screenshot',
+          suite_title: 'suite',
+          status: 'failed',
+          message: 'failure',
+          artifacts: [artifactPath],
+        },
+      ],
+      outputPath: out,
+      templatePath: template,
+      warningMsg: '',
+    });
+
+    const copiedArtifact = path.join(testOutputDir, 'artifacts', 'failed screenshot.png');
+    const html = fs.readFileSync(out, 'utf-8');
+
+    expect(fs.existsSync(copiedArtifact)).to.equal(true);
+    expect(html).to.include('./artifacts/failed screenshot.png');
+    expect(html).to.not.include(`file:///${artifactPath.replace(/\\/g, '/')}`);
+  });
+
+  it('copies local step artifacts next to HTML report and rewrites step links to relative paths', () => {
+    process.env.TESTOMATIO_HTML_REPORT_SAVE = '1';
+
+    const template = path.resolve(dirname, '../../..', 'src', 'template', 'testomatio.hbs');
+    const out = path.resolve(testOutputDir, 'with-local-step-artifact.html');
+    const artifactPath = path.resolve(testOutputDir, 'step-screenshot.png');
+    fs.writeFileSync(artifactPath, 'fake image');
+
+    const pipe = new HtmlPipe({ htmlCopyArtifacts: true }, {});
+    pipe.buildReport({
+      runParams: { status: 'failed' },
+      tests: [
+        {
+          title: 'failed step with screenshot',
+          suite_title: 'suite',
+          status: 'failed',
+          message: 'failure',
+          steps: [
+            {
+              category: 'user',
+              title: 'Click submit',
+              artifacts: [artifactPath],
+            },
+          ],
+        },
+      ],
+      outputPath: out,
+      templatePath: template,
+      warningMsg: '',
+    });
+
+    const copiedArtifact = path.join(testOutputDir, 'artifacts', 'step-screenshot.png');
+    const html = fs.readFileSync(out, 'utf-8');
+
+    expect(fs.existsSync(copiedArtifact)).to.equal(true);
+    expect(html).to.include('./artifacts/step-screenshot.png');
+    expect(html).to.not.include(`file:///${artifactPath.replace(/\\/g, '/')}`);
+  });
+
   it('renders run description (markdown) from store as a Description section', () => {
     process.env.TESTOMATIO_HTML_REPORT_SAVE = '1';
 

--- a/tests/unit/pipes/html_pipe_test.js
+++ b/tests/unit/pipes/html_pipe_test.js
@@ -115,11 +115,27 @@ describe('HTML report tests', () => {
   // const testOutputDir = path.resolve(dirname, 'htmlOutput');
   const testOutputDir = path.resolve(process.cwd(), 'htmlOutput');
   let filepath = '';
+  let originalS3Bucket;
+  let originalDisableArtifacts;
+  let originalHtmlCopyArtifacts;
 
   before(() => {
     if (!fs.existsSync(testOutputDir)) {
       fs.mkdirSync(testOutputDir);
     }
+  });
+  beforeEach(() => {
+    originalS3Bucket = process.env.S3_BUCKET;
+    originalDisableArtifacts = process.env.TESTOMATIO_DISABLE_ARTIFACTS;
+    originalHtmlCopyArtifacts = process.env.TESTOMATIO_HTML_REPORT_COPY_ARTIFACTS;
+    delete process.env.S3_BUCKET;
+    delete process.env.TESTOMATIO_DISABLE_ARTIFACTS;
+    delete process.env.TESTOMATIO_HTML_REPORT_COPY_ARTIFACTS;
+  });
+  afterEach(() => {
+    restoreEnv('S3_BUCKET', originalS3Bucket);
+    restoreEnv('TESTOMATIO_DISABLE_ARTIFACTS', originalDisableArtifacts);
+    restoreEnv('TESTOMATIO_HTML_REPORT_COPY_ARTIFACTS', originalHtmlCopyArtifacts);
   });
   after(async () => {
     try {
@@ -464,11 +480,11 @@ describe('HTML report tests', () => {
     expect(htmlContent).to.not.include('file:///D:/testomat/reporter/https:/example-bucket.r2.cloudflarestorage.com');
   });
 
-  it('keeps local artifact file URLs by default', () => {
+  it('copies local artifact links by default when S3 uploading is not configured', () => {
     process.env.TESTOMATIO_HTML_REPORT_SAVE = '1';
 
     const template = path.resolve(dirname, '../../..', 'src', 'template', 'testomatio.hbs');
-    const out = path.resolve(testOutputDir, 'with-default-local-artifact.html');
+    const out = path.resolve(testOutputDir, 'with-default-portable-local-artifact.html');
     const artifactPath = path.resolve(testOutputDir, 'default-local-screenshot.png');
     fs.writeFileSync(artifactPath, 'fake image');
 
@@ -492,9 +508,147 @@ describe('HTML report tests', () => {
     const copiedArtifact = path.join(testOutputDir, 'artifacts', 'default-local-screenshot.png');
     const html = fs.readFileSync(out, 'utf-8');
 
+    expect(fs.existsSync(copiedArtifact)).to.equal(true);
+    expect(html).to.include('./artifacts/default-local-screenshot.png');
+    expect(html).to.not.include(artifactFileUrl(artifactPath));
+  });
+
+  it('keeps local artifact file URLs by default when S3 uploading is configured', () => {
+    process.env.TESTOMATIO_HTML_REPORT_SAVE = '1';
+    process.env.S3_BUCKET = 'test-bucket';
+
+    const template = path.resolve(dirname, '../../..', 'src', 'template', 'testomatio.hbs');
+    const out = path.resolve(testOutputDir, 'with-s3-local-artifact.html');
+    const artifactPath = path.resolve(testOutputDir, 's3-local-screenshot.png');
+    fs.writeFileSync(artifactPath, 'fake image');
+
+    const pipe = new HtmlPipe({}, {});
+    pipe.buildReport({
+      runParams: { status: 'failed' },
+      tests: [
+        {
+          title: 'failed with s3 screenshot behavior',
+          suite_title: 'suite',
+          status: 'failed',
+          message: 'failure',
+          artifacts: [artifactPath],
+        },
+      ],
+      outputPath: out,
+      templatePath: template,
+      warningMsg: '',
+    });
+
+    const copiedArtifact = path.join(testOutputDir, 'artifacts', 's3-local-screenshot.png');
+    const html = fs.readFileSync(out, 'utf-8');
+
     expect(fs.existsSync(copiedArtifact)).to.equal(false);
     expect(html).to.include(artifactFileUrl(artifactPath));
-    expect(html).to.not.include('./artifacts/default-local-screenshot.png');
+    expect(html).to.not.include('./artifacts/s3-local-screenshot.png');
+  });
+
+  it('checks S3 uploading config when building the HTML report', () => {
+    process.env.TESTOMATIO_HTML_REPORT_SAVE = '1';
+
+    const template = path.resolve(dirname, '../../..', 'src', 'template', 'testomatio.hbs');
+    const out = path.resolve(testOutputDir, 'with-late-s3-local-artifact.html');
+    const artifactPath = path.resolve(testOutputDir, 'late-s3-local-screenshot.png');
+    fs.writeFileSync(artifactPath, 'fake image');
+
+    const pipe = new HtmlPipe({}, {});
+    process.env.S3_BUCKET = 'test-bucket';
+
+    pipe.buildReport({
+      runParams: { status: 'failed' },
+      tests: [
+        {
+          title: 'failed with late s3 screenshot behavior',
+          suite_title: 'suite',
+          status: 'failed',
+          message: 'failure',
+          artifacts: [artifactPath],
+        },
+      ],
+      outputPath: out,
+      templatePath: template,
+      warningMsg: '',
+    });
+
+    const copiedArtifact = path.join(testOutputDir, 'artifacts', 'late-s3-local-screenshot.png');
+    const html = fs.readFileSync(out, 'utf-8');
+
+    expect(fs.existsSync(copiedArtifact)).to.equal(false);
+    expect(html).to.include(artifactFileUrl(artifactPath));
+    expect(html).to.not.include('./artifacts/late-s3-local-screenshot.png');
+  });
+
+  it('copies local artifact links when S3 uploading is disabled', () => {
+    process.env.TESTOMATIO_HTML_REPORT_SAVE = '1';
+    process.env.S3_BUCKET = 'test-bucket';
+    process.env.TESTOMATIO_DISABLE_ARTIFACTS = '1';
+
+    const template = path.resolve(dirname, '../../..', 'src', 'template', 'testomatio.hbs');
+    const out = path.resolve(testOutputDir, 'with-disabled-s3-local-artifact.html');
+    const artifactPath = path.resolve(testOutputDir, 'disabled-s3-local-screenshot.png');
+    fs.writeFileSync(artifactPath, 'fake image');
+
+    const pipe = new HtmlPipe({}, {});
+    pipe.buildReport({
+      runParams: { status: 'failed' },
+      tests: [
+        {
+          title: 'failed with disabled s3 screenshot behavior',
+          suite_title: 'suite',
+          status: 'failed',
+          message: 'failure',
+          artifacts: [artifactPath],
+        },
+      ],
+      outputPath: out,
+      templatePath: template,
+      warningMsg: '',
+    });
+
+    const copiedArtifact = path.join(testOutputDir, 'artifacts', 'disabled-s3-local-screenshot.png');
+    const html = fs.readFileSync(out, 'utf-8');
+
+    expect(fs.existsSync(copiedArtifact)).to.equal(true);
+    expect(html).to.include('./artifacts/disabled-s3-local-screenshot.png');
+    expect(html).to.not.include(artifactFileUrl(artifactPath));
+  });
+
+  it('allows explicit env override to keep local artifact file URLs without S3', () => {
+    process.env.TESTOMATIO_HTML_REPORT_SAVE = '1';
+    process.env.TESTOMATIO_HTML_REPORT_COPY_ARTIFACTS = '0';
+
+    const template = path.resolve(dirname, '../../..', 'src', 'template', 'testomatio.hbs');
+    const out = path.resolve(testOutputDir, 'with-disabled-local-copy-artifact.html');
+    const artifactPath = path.resolve(testOutputDir, 'disabled-copy-screenshot.png');
+    fs.writeFileSync(artifactPath, 'fake image');
+
+    const pipe = new HtmlPipe({}, {});
+    pipe.buildReport({
+      runParams: { status: 'failed' },
+      tests: [
+        {
+          title: 'failed with disabled copy screenshot behavior',
+          suite_title: 'suite',
+          status: 'failed',
+          message: 'failure',
+          artifacts: [artifactPath],
+        },
+      ],
+      outputPath: out,
+      templatePath: template,
+      warningMsg: '',
+    });
+
+    const copiedArtifact = path.join(testOutputDir, 'artifacts', 'disabled-copy-screenshot.png');
+    const html = fs.readFileSync(out, 'utf-8');
+
+    expect(fs.existsSync(copiedArtifact)).to.equal(false);
+    expect(html).to.include(artifactFileUrl(artifactPath));
+    expect(html).to.not.include('./artifacts/disabled-copy-screenshot.png');
   });
 
   it('copies local test artifacts next to HTML report and rewrites links to relative paths', () => {
@@ -655,4 +809,12 @@ function getCurrentDate() {
 
 function artifactFileUrl(filePath) {
   return fileUrl(filePath, { resolve: true });
+}
+
+function restoreEnv(name, value) {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
 }

--- a/tests/unit/pipes/html_pipe_test.js
+++ b/tests/unit/pipes/html_pipe_test.js
@@ -4,6 +4,7 @@ import path from 'path';
 import { JSDOM } from 'jsdom';
 import HtmlPipe from '../../../src/pipe/html.js';
 import { fileURLToPath } from 'url';
+import fileUrl from 'file-url';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -428,7 +429,9 @@ describe('HTML report tests', () => {
 
     expect(htmlContent).to.include('.message-block.passed');
     expect(htmlContent).to.include("if (hasMessage) return 'message';");
-    expect(htmlContent).to.include("const initialTab = getInitialTestTab({ isTodo, hasMessage, hasSteps: test.stepsArray?.length || test.steps });");
+    expect(htmlContent).to.include(
+      "const initialTab = getInitialTestTab({ isTodo, hasMessage, hasSteps: test.stepsArray?.length || test.steps });",
+    );
     expect(htmlContent).to.include("button class='test-tab${initialMessageClass}'");
     expect(htmlContent).to.include("div class='test-tab-content${initialMessageClass}' data-tab='message'");
   });
@@ -490,7 +493,7 @@ describe('HTML report tests', () => {
     const html = fs.readFileSync(out, 'utf-8');
 
     expect(fs.existsSync(copiedArtifact)).to.equal(false);
-    expect(html).to.include(`file:///${artifactPath.replace(/\\/g, '/')}`);
+    expect(html).to.include(artifactFileUrl(artifactPath));
     expect(html).to.not.include('./artifacts/default-local-screenshot.png');
   });
 
@@ -524,7 +527,7 @@ describe('HTML report tests', () => {
 
     expect(fs.existsSync(copiedArtifact)).to.equal(true);
     expect(html).to.include('./artifacts/failed screenshot.png');
-    expect(html).to.not.include(`file:///${artifactPath.replace(/\\/g, '/')}`);
+    expect(html).to.not.include(artifactFileUrl(artifactPath));
   });
 
   it('copies local step artifacts next to HTML report and rewrites step links to relative paths', () => {
@@ -563,7 +566,7 @@ describe('HTML report tests', () => {
 
     expect(fs.existsSync(copiedArtifact)).to.equal(true);
     expect(html).to.include('./artifacts/step-screenshot.png');
-    expect(html).to.not.include(`file:///${artifactPath.replace(/\\/g, '/')}`);
+    expect(html).to.not.include(artifactFileUrl(artifactPath));
   });
 
   it('renders run description (markdown) from store as a Description section', () => {
@@ -648,4 +651,8 @@ function getCurrentDate() {
   const year = currentDate.getFullYear();
 
   return `(${day}/${month}/${year}`;
+}
+
+function artifactFileUrl(filePath) {
+  return fileUrl(filePath, { resolve: true });
 }


### PR DESCRIPTION
 ## Summary 

Adds an opt-in mode for HTML reports to copy local artifacts into the report folder and rewrite their links to relative paths.                                                                     

This is useful for Jenkins and other CI artifact viewers where `file://` or absolute local paths are not accessible after the report is published.                                                                                                                                                                                           