### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "lib/reporter.js",
   "module": "src/reporter.js",
   "types": "types/types.d.ts",
-  "repository": "git@github.com:testomatio/reporter.git",
+  "repository": "git+https://github.com/testomatio/reporter.git",
   "author": "Michael Bodnarchuk <davert@testomat.io>,Koushik Mohan <koushikmohan1996@gmail.com>",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- replace the SSH-style repository metadata with a public HTTPS Git URL
- keep the package metadata installable without requiring SSH access to GitHub

## Verification
- `node -e "const p=require('./package.json'); console.log(p.name,p.version,p.repository)"`
- `npm install --ignore-scripts --no-audit --no-fund`
- `npm run lint`
- `npm test`
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`
