### PR TITLE
show CodeceptJS DataTable examples in  report titles

### DIFF
--- a/src/pipe/html.js
+++ b/src/pipe/html.js
@@ -228,6 +228,8 @@ class HtmlPipe {
         test.title = 'Unknown test title';
       }
 
+      test.title = buildExampleTitle(test.title, test.example);
+
       test.artifacts = normalizeArtifacts(test);
 
       const allPossibleArtifacts = [
@@ -458,6 +460,21 @@ function parseRetryInfo(test) {
     const n = Number(test.meta.retryCount);
     if (!Number.isNaN(n)) test.retries.retryCount = n;
   }
+}
+
+function buildExampleTitle(title, example) {
+  if (example == null) return title;
+
+  let exampleText;
+  try {
+    exampleText = JSON.stringify(example);
+  } catch (e) {
+    return title;
+  }
+
+  if (!exampleText || title.includes(exampleText)) return title;
+
+  return `${title} | ${exampleText}`;
 }
 
 function escapeHtml(str = '') {

--- a/tests/unit/pipes/html_pipe_test.js
+++ b/tests/unit/pipes/html_pipe_test.js
@@ -441,6 +441,40 @@ describe('HTML report tests', () => {
     expect(todoTestsFromData).to.have.length(1);
   });
 
+  it('should render CodeceptJS DataTable examples in test titles', () => {
+    process.env.TESTOMATIO_HTML_REPORT_SAVE = '1';
+
+    const template = path.resolve(dirname, '../../..', 'src', 'template', 'testomatio.hbs');
+    const out = path.resolve(testOutputDir, 'datatable-examples.html');
+    const pipe = new HtmlPipe({}, {});
+    pipe.buildReport({
+      runParams: { status: 'passed' },
+      tests: [
+        {
+          rid: 'datatable-1',
+          title: 'test something',
+          suite_title: 'My',
+          status: 'passed',
+          example: { input: 'input1', expected: 'expected1' },
+        },
+        {
+          rid: 'datatable-2',
+          title: 'test something',
+          suite_title: 'My',
+          status: 'passed',
+          example: { input: 'input2', expected: 'expected2' },
+        },
+      ],
+      outputPath: out,
+      templatePath: template,
+      warningMsg: '',
+    });
+
+    const html = fs.readFileSync(out, 'utf-8');
+    expect(html).to.include('test something | {\\"input\\":\\"input1\\",\\"expected\\":\\"expected1\\"}');
+    expect(html).to.include('test something | {\\"input\\":\\"input2\\",\\"expected\\":\\"expected2\\"}');
+  });
+
   it('should style passed messages without failed color and prefer message tab when message exists', () => {
     const htmlContent = fs.readFileSync(filepath, 'utf-8');
 


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                    
  - Restore CodeceptJS DataTable example values in HTML report test titles                                                                                                                      
  - Keep API/Testomat.io payload behavior unchanged                                                                                                                                             
  - Add HTML pipe coverage for duplicated base titles with different examples 
  
  https://github.com/testomatio/reporter/issues/858