### PR TITLE
Preserve step artifacts when uploading artifacts from JSONL debug files

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -310,7 +310,7 @@ This approach is useful when:
 **Notes:**
 - The JSONL file must contain a valid `runId` and tests with `test_id` set
 - **CodeceptJS only**: trace.zip and video files are automatically recorded when using `TESTOMATIO_DEBUG=1`
-- Artifacts are uploaded to the test level (Artifacts tab), not within individual steps
+- Test-level `files` are uploaded to the test artifacts tab; `steps[].artifacts` are uploaded back into their corresponding steps
 
 ### 6. replay
 

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -23,28 +23,6 @@ const debug = createDebugMessages('@testomatio/reporter:cli');
 const version = getPackageVersion();
 const program = new Command();
 
-function hasExistingArtifacts(test) {
-  const hasExistingFile = items => {
-    for (const item of items || []) {
-      const artifactPath = typeof item === 'object' ? item?.path : item;
-      if (artifactPath && fs.existsSync(artifactPath)) return true;
-    }
-    return false;
-  };
-
-  if (hasExistingFile(test.files)) return true;
-
-  const stack = [...(test.steps || [])];
-  while (stack.length) {
-    const step = stack.pop();
-    if (!step) continue;
-    if (hasExistingFile(step.artifacts)) return true;
-    if (Array.isArray(step.steps)) stack.push(...step.steps);
-  }
-
-  return false;
-}
-
 program
   .version(version)
   .option('--env-file <envfile>', 'Load environment variables from env file')
@@ -573,6 +551,28 @@ program
       process.exit(1);
     }
   });
+
+function hasExistingArtifacts(test) {
+  const hasExistingFile = items => {
+    for (const item of items || []) {
+      const artifactPath = typeof item === 'object' ? item?.path : item;
+      if (artifactPath && fs.existsSync(artifactPath)) return true;
+    }
+    return false;
+  };
+
+  if (hasExistingFile(test.files)) return true;
+
+  const stack = [...(test.steps || [])];
+  while (stack.length) {
+    const step = stack.pop();
+    if (!step) continue;
+    if (hasExistingFile(step.artifacts)) return true;
+    if (Array.isArray(step.steps)) stack.push(...step.steps);
+  }
+
+  return false;
+}
 
 program.parse(process.argv);
 

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -18,12 +18,32 @@ import { log } from '../utils/log.js';
 import { formatFilterListIds } from '../utils/pipe_utils.js';
 import fs from 'fs';
 import path from 'path';
-import { Gaxios } from 'gaxios';
-import { generateShortFilename } from '../adapter/utils/step-formatter.js';
 
 const debug = createDebugMessages('@testomatio/reporter:cli');
 const version = getPackageVersion();
 const program = new Command();
+
+function hasExistingArtifacts(test) {
+  const hasExistingFile = items => {
+    for (const item of items || []) {
+      const artifactPath = typeof item === 'object' ? item?.path : item;
+      if (artifactPath && fs.existsSync(artifactPath)) return true;
+    }
+    return false;
+  };
+
+  if (hasExistingFile(test.files)) return true;
+
+  const stack = [...(test.steps || [])];
+  while (stack.length) {
+    const step = stack.pop();
+    if (!step) continue;
+    if (hasExistingFile(step.artifacts)) return true;
+    if (Array.isArray(step.steps)) stack.push(...step.steps);
+  }
+
+  return false;
+}
 
 program
   .version(version)
@@ -390,58 +410,17 @@ program
       client.uploader.checkEnabled();
       client.uploader.disableLogStorage();
 
-      const apiUrl = process.env.TESTOMATIO_URL || 'https://app.testomat.io';
-      const http = new Gaxios();
       let uploadedCount = 0;
       let failedCount = 0;
 
       for (const test of tests) {
-        const testId = test.test_id;
-        if (!testId) continue;
-
-        const artifacts = [];
-
-        const collect = (items) => {
-          for (const item of items || []) {
-            const p = typeof item === 'object' ? item?.path : item;
-            if (p && fs.existsSync(p)) artifacts.push(p);
-          }
-        };
-        collect(test.files);
-
-        const walkSteps = (steps) => {
-          for (const step of steps || []) {
-            collect(step.artifacts);
-            walkSteps(step.steps);
-          }
-        };
-        walkSteps(test.steps);
-
-        if (artifacts.length === 0) continue;
-
-        const urls = [];
-        for (const artifact of artifacts) {
-          try {
-            const s3Id = test.rid || testId.replace('@', '');
-            const filename = generateShortFilename(artifact);
-            const result = await client.uploader.uploadFileByPath(artifact, [runId, s3Id, filename]);
-            if (result) urls.push(typeof result === 'string' ? result : result.link);
-          } catch (e) {
-            debug(`Failed to upload ${artifact}:`, e.message);
-          }
-        }
-
-        if (urls.length === 0) continue;
+        if (!hasExistingArtifacts(test)) continue;
 
         try {
-          await http.request({
-            method: 'POST',
-            url: `${apiUrl}/api/reporter/${runId}/testrun?api_key=${apiKey}`,
-            data: { test_id: testId, artifacts: urls },
-          });
+          await client.addTestRun(undefined, { ...test, overwrite: true });
           uploadedCount++;
         } catch (e) {
-          log.error(`Failed ${testId}: ${e.message}`);
+          log.error(`Failed ${test.test_id || test.rid || test.title}: ${e.message}`);
           failedCount++;
         }
       }

--- a/src/client.js
+++ b/src/client.js
@@ -159,11 +159,12 @@ class Client {
 
         const uploadedArtifacts = [];
         for (const artifact of step.artifacts) {
-          if (typeof artifact === 'string' && !isHttpUrl(artifact)) {
-            const filename = generateShortFilename(artifact);
+          const artifactPath = typeof artifact === 'object' ? artifact?.path : artifact;
+          if (typeof artifactPath === 'string' && !isHttpUrl(artifactPath)) {
+            const filename = generateShortFilename(artifactPath);
             try {
               const uploadResult = await this.uploader.uploadFileByPath(
-                artifact, 
+                artifactPath,
                 [this.runId, testRid, 'steps', filename]
               );
               if (uploadResult) {

--- a/tests/unit/client_stack_artifacts_test.js
+++ b/tests/unit/client_stack_artifacts_test.js
@@ -22,6 +22,72 @@ describe('Client Stack Artifacts', () => {
     delete process.env.TESTOMATIO_STACK_ARTIFACTS;
   });
 
+  it('uploads step artifacts into steps and excludes them from test artifacts', async () => {
+    const pipeCalls = [];
+    client.pipes = [
+      {
+        isEnabled: true,
+        toString: () => 'FakePipe',
+        addTest: async data => {
+          pipeCalls.push(data);
+        },
+      },
+    ];
+
+    client.uploader.isEnabled = true;
+    client.uploader.uploadFileByPath = async (filePath, s3Path) => {
+      uploadCalls.push({ filePath, path: s3Path });
+      return `https://bucket.example/${s3Path.join('/')}`;
+    };
+
+    await client.addTestRun('failed', {
+      rid: 'test-rid',
+      test_id: '@T123',
+      title: 'Test with step artifact',
+      suite_title: 'Suite',
+      files: [
+        { path: 'logs/test/test_1.jpg' },
+        { path: 'logs/step/Step_1.jpg' },
+      ],
+      steps: [
+        {
+          title: 'Parent step',
+          artifacts: ['logs/step/Step_1.jpg'],
+          steps: [
+            {
+              title: 'Nested step',
+              artifacts: [{ path: 'logs/step/Step_2.jpg' }],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(uploadCalls).to.have.length(3);
+    expect(uploadCalls[0].path).to.deep.equal([
+      'test-run-123',
+      'test-rid',
+      'steps',
+      'Step_1.jpg',
+    ]);
+    expect(uploadCalls[1].path).to.deep.equal([
+      'test-run-123',
+      'test-rid',
+      'steps',
+      'Step_2.jpg',
+    ]);
+    expect(uploadCalls[2].path).to.deep.equal(['test-run-123', 'test-rid', 'test_1.jpg']);
+
+    expect(pipeCalls).to.have.length(1);
+    expect(pipeCalls[0].artifacts).to.deep.equal(['https://bucket.example/test-run-123/test-rid/test_1.jpg']);
+    expect(pipeCalls[0].steps[0].artifacts).to.deep.equal([
+      'https://bucket.example/test-run-123/test-rid/steps/Step_1.jpg',
+    ]);
+    expect(pipeCalls[0].steps[0].steps[0].artifacts).to.deep.equal([
+      'https://bucket.example/test-run-123/test-rid/steps/Step_2.jpg',
+    ]);
+  });
+
   it('keeps constructor pipe config when createRun receives runtime params', async () => {
     const reportDir = path.join('output', 'report');
     const reportRoot = path.resolve(process.cwd(), 'output');


### PR DESCRIPTION
## Summary                                                                                                                                                                                  
Fixes `upload-artifacts <jsonl-file>` so artifacts declared in `steps[].artifacts` are uploaded back into their corresponding steps instead of being attached to the test-level artifacts list.                                                                                                                                                                                       
                                                                                                                                                                                              
  ## Changes                                                                                                                                                                                  
                                                                                                                                                                                              
  - Reuse `client.addTestRun` for JSONL artifact uploads instead of manually posting `{ test_id, artifacts }`. 
  - Keep test-level `files` and step-level `steps[].artifacts` separated during upload.   
  - Support step artifact entries in both string and `{ path }` formats. 
  - Add regression coverage for nested step artifacts.
  - Update CLI docs for JSONL artifact upload behavior.