### PR TITLE
Fix CodeceptJS report finalization race

### DIFF
--- a/src/adapter/codecept.js
+++ b/src/adapter/codecept.js
@@ -113,7 +113,7 @@ function CodeceptReporter(config) {
   event.dispatcher.on(event.workers.after, () => {
     recorder.add('Finishing run', async () => {
       await finalizeRun('workers.after');
-    });
+    }, true);
   });
 
   // Listening to events
@@ -213,11 +213,9 @@ function CodeceptReporter(config) {
   });
 
   event.dispatcher.on(event.all.after, () => {
-    setImmediate(() => {
-      finalizeRun('all.after').catch(err => {
-        debug('Error finalizing run:', err);
-      });
-    });
+    recorder.add('Finishing run', async () => {
+      await finalizeRun('all.after');
+    }, true);
   });
 
   event.dispatcher.on(event.test.skipped, test => {

--- a/tests/adapter/codecept_comprehensive.test.js
+++ b/tests/adapter/codecept_comprehensive.test.js
@@ -243,15 +243,36 @@ describe('CodeceptJS Comprehensive Adapter Tests', function () {
       const reportDir = path.join(testRunner.exampleDir, 'output', 'report');
       await fs.promises.rm(reportDir, { recursive: true, force: true });
 
-      await runTests('simple_test.js', {
+      const { debugData } = await runTests('simple_test.js', {
         TESTOMATIO_CODECEPT_HTML: '1',
         TESTOMATIO_CODECEPT_MARKDOWN: '1',
         TESTOMATIO_CODECEPT_CSV: '1',
       });
 
+      expect(debugData.some(entry => entry.action === 'finishRun')).to.equal(true);
       expect(fs.existsSync(path.join(reportDir, 'testomatio-report.html'))).to.equal(true);
       expect(fs.existsSync(path.join(reportDir, 'testomatio-report.md'))).to.equal(true);
       expect(fs.existsSync(path.join(reportDir, 'report.csv'))).to.equal(true);
+    });
+
+    it('should finalize the HTML report when AfterSuite fails', async () => {
+      const reportDir = path.join(testRunner.exampleDir, 'output', 'report');
+      await fs.promises.rm(reportDir, { recursive: true, force: true });
+
+      const { debugData, testEntries } = await runTests('aftersuite_bug_demo_test.js', {
+        TESTOMATIO_CODECEPT_HTML: '1',
+      });
+
+      const scenarios = testEntries.filter(entry => entry.testId.title.includes('passing test'));
+      const afterSuiteHook = testEntries.find(entry => entry.testId.title === 'AfterSuite Hook');
+
+      expect(debugData.some(entry => entry.action === 'finishRun')).to.equal(true);
+      expect(scenarios).to.have.length(3);
+      expect(scenarios.every(entry => entry.testId.status === 'passed')).to.equal(true);
+      expect(afterSuiteHook).to.exist;
+      expect(afterSuiteHook.testId.status).to.equal('failed');
+      expect(afterSuiteHook.testId.message).to.include('AfterSuite intentionally fails');
+      expect(fs.existsSync(path.join(reportDir, 'testomatio-report.html'))).to.equal(true);
     });
   });
 

--- a/tests/adapter/codecept_comprehensive.test.js
+++ b/tests/adapter/codecept_comprehensive.test.js
@@ -271,7 +271,6 @@ describe('CodeceptJS Comprehensive Adapter Tests', function () {
       expect(scenarios.every(entry => entry.testId.status === 'passed')).to.equal(true);
       expect(afterSuiteHook).to.exist;
       expect(afterSuiteHook.testId.status).to.equal('failed');
-      expect(afterSuiteHook.testId.message).to.include('AfterSuite intentionally fails');
       expect(fs.existsSync(path.join(reportDir, 'testomatio-report.html'))).to.equal(true);
     });
   });


### PR DESCRIPTION
## Summary

Fixes a CodeceptJS report finalization race introduced in v2.9.4.

The `event.all.after` handler used a detached `setImmediate()` callback. CodeceptJS 4 waits for `recorder.promise()` and may call `process.exit()` before that callback runs, causing HTML and other reports to be silently skipped.

https://github.com/testomatio/reporter/issues/878