### PR TITLE
Fix CodeceptJS test statuses after BeforeSuite failure

### DIFF
--- a/src/adapter/codecept.js
+++ b/src/adapter/codecept.js
@@ -152,12 +152,33 @@ function CodeceptReporter(config) {
     services.setContext(null);
   });
 
-  // mark as failed all tests inside the failed hook
+  // Report setup hook failures against the current test while preserving skipped tests in the suite.
   event.dispatcher.on(event.hook.failed, hook => {
     const error = hook?.ctx?.currentTest?.err || hook?.err;
 
-    // Handle BeforeSuite and Before hooks: mark all tests in suite as failed
-    if (hook.name === 'BeforeSuiteHook' || hook.name === 'BeforeHook') {
+    // CodeceptJS does not emit test.after for the test associated with a failed BeforeSuite,
+    // so report that test here. The remaining tests are emitted as skipped.
+    if (hook.name === 'BeforeSuiteHook') {
+      const suite = hook.runnable?.parent || hook.suite;
+      if (!suite) return;
+
+      const test = hook?.ctx?.currentTest || hook?.test || suite.tests?.[0];
+      if (!test) return;
+
+      reportedTestUids.add(test.uid);
+      const reportTestPromise = client.addTestRun(STATUS.FAILED, {
+        ...stripExampleFromTitle(test.title),
+        rid: test.uid,
+        test_id: getTestomatIdFromTestTitle(test.title),
+        suite_title: stripTagsFromTitle(suite.title),
+        error,
+        time: hook?.runnable?.duration,
+      });
+      reportTestPromises.push(reportTestPromise);
+    }
+
+    // Preserve the existing Before hook behavior: mark all tests in the suite as failed.
+    if (hook.name === 'BeforeHook') {
       const suite = hook.runnable.parent;
       if (!suite) return;
 

--- a/tests/adapter/codecept_beforesuite_failure.test.js
+++ b/tests/adapter/codecept_beforesuite_failure.test.js
@@ -4,11 +4,8 @@ import { runTests } from '../adapter/utils/codecept.js';
 describe('CodeceptJS BeforeSuite Failure Tests', function () {
   this.timeout(60000);
 
-  it('should mark all tests as failed when BeforeSuite fails', async () => {
-    const { debugData } = await runTests('beforesuite_failure_test.js');
-
-    // Find all test entries
-    const testEntries = debugData.filter(entry => entry.action === 'addTest' && entry.testId && entry.testId.title);
+  it('should fail the current test and skip the remaining tests when BeforeSuite fails', async () => {
+    const { testEntries } = await runTests('beforesuite_failure_test.js');
 
     // Should have 3 tests
     expect(testEntries).to.have.lengthOf(3);
@@ -20,19 +17,18 @@ describe('CodeceptJS BeforeSuite Failure Tests', function () {
       'test teams can be deleted',
     ]);
 
-    // All tests should have failed status
-    for (const entry of testEntries) {
-      expect(entry.testId.status).to.equal('failed');
-    }
+    const failedTests = testEntries.filter(entry => entry.testId.status === 'failed');
+    const skippedTests = testEntries.filter(entry => entry.testId.status === 'skipped');
+
+    expect(failedTests).to.have.lengthOf(1);
+    expect(failedTests[0].testId.title).to.equal('test teams can be created');
+    expect(skippedTests).to.have.lengthOf(2);
   });
 
   it('should report BeforeSuite failure in test results', async () => {
-    const { debugData } = await runTests('beforesuite_failure_test.js');
+    const { testEntries } = await runTests('beforesuite_failure_test.js');
 
-    // Find any failed test (they should all have the BeforeSuite error)
-    const failedTest = debugData.find(
-      entry => entry.action === 'addTest' && entry.testId && entry.testId.status === 'failed',
-    );
+    const failedTest = testEntries.find(entry => entry.testId.status === 'failed');
 
     expect(failedTest).to.exist;
 


### PR DESCRIPTION
## Summary

  - Fix CodeceptJS test statuses when `BeforeSuite` fails.
  - Report only the test associated with the failed hook as failed.
  - Preserve skipped statuses for the remaining tests.
  - Keep the existing `BeforeHook` behavior unchanged.

https://github.com/testomatio/app/issues/1137