### PR TITLE
convert timestamp to Unix seconds

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -206,9 +206,9 @@ class Client {
         suite_title: 'Unknown suite',
       };
 
-    // Add timestamp if not already present (microseconds since Unix epoch)
+    // Add timestamp if not already present (Unix seconds)
     if (!testData.timestamp && !process.env.TESTOMATIO_NO_TIMESTAMP) {
-      testData.timestamp = Math.floor((performance.timeOrigin + performance.now()) * 1000);
+      testData.timestamp = Math.floor((performance.timeOrigin + performance.now()) / 1000);
     }
 
     /**

--- a/src/pipe/testomatio.js
+++ b/src/pipe/testomatio.js
@@ -167,6 +167,12 @@ class TestomatioPipe {
     // add test ID + run ID
     if (data.rid) data.rid = `${this.runId}-${data.rid}`;
 
+    // convert timestamp to seconds
+    if (data.timestamp > 1e11) {
+      if (data.timestamp > 1e14) data.timestamp = Math.floor(data.timestamp / 1e6); // convert microseconds
+      else if (data.timestamp > 1e11) data.timestamp = Math.floor(data.timestamp / 1e3); // convert milliseconds
+    }
+
     if (!process.env.TESTOMATIO_STACK_PASSED && data.status === STATUS.PASSED) {
       data.stack = null;
     }

--- a/tests/unit/pipes/testomatio_pipe_test.js
+++ b/tests/unit/pipes/testomatio_pipe_test.js
@@ -1141,6 +1141,63 @@ describe('TestomatioPipe', () => {
         expect(testData.create).to.equal(true);
       });
     });
+
+    describe('timestamp normalization', () => {
+      it('should convert a microsecond timestamp to Unix seconds', () => {
+        const testData = {
+          title: 'Test with microsecond timestamp',
+          status: 'passed',
+          timestamp: 1750000000000000, // microseconds
+        };
+
+        pipe.addTest(testData);
+        expect(testData.timestamp).to.equal(1750000000);
+      });
+
+      it('should convert a millisecond timestamp to Unix seconds', () => {
+        const testData = {
+          title: 'Test with millisecond timestamp',
+          status: 'passed',
+          timestamp: 1750000000000, // milliseconds
+        };
+
+        pipe.addTest(testData);
+        expect(testData.timestamp).to.equal(1750000000);
+      });
+
+      it('should leave a timestamp already in Unix seconds unchanged', () => {
+        const testData = {
+          title: 'Test with seconds timestamp',
+          status: 'passed',
+          timestamp: 1750000000, // seconds
+        };
+
+        pipe.addTest(testData);
+        expect(testData.timestamp).to.equal(1750000000);
+      });
+
+      it('should not add a timestamp when none is provided', () => {
+        const testData = {
+          title: 'Test without timestamp',
+          status: 'passed',
+        };
+
+        pipe.addTest(testData);
+        expect(testData.timestamp).to.be.undefined;
+      });
+
+      it('should not re-divide the timestamp when the object is formatted twice', () => {
+        const testData = {
+          title: 'Test with microsecond timestamp',
+          status: 'passed',
+          timestamp: 1750000000000000, // microseconds
+        };
+
+        pipe.addTest(testData);
+        pipe.addTest(testData);
+        expect(testData.timestamp).to.equal(1750000000);
+      });
+    });
   });
 
   describe('error logging behavior (testing via public methods)', () => {


### PR DESCRIPTION
Ticket: https://github.com/testomatio/reporter/issues/817

Added timestamp normalization in Testomatio Pipe