### PR TITLE
Add Dart test adapter support (Patrol/Flutter)

### DIFF
--- a/src/junit-adapter/dart.js
+++ b/src/junit-adapter/dart.js
@@ -4,7 +4,7 @@ import Adapter from './adapter.js';
 class DartAdapter extends Adapter {
   
   getFilePath(t) {
-    if (t.title.includes('[')) {
+    if (t.title.startsWith('runDartTest[')) {
       // Android: runDartTest[tests.path.to.test Test name]
       const fileName = namespaceToFileName(t.title.split('[')[1].split(' ')[0]);
       return fileName;
@@ -16,14 +16,13 @@ class DartAdapter extends Adapter {
   }
 
   formatTest(t) {
-    // Save original title for file path resolution before any transformations
-    t.originalTitle = t.title;
-
-    if (t.title.includes('[')) {
+    if (t.title.startsWith('runDartTest[')) {
       // Android: runDartTest[<path> <name>]
       // First space is between the path and the test name; strip up to and including it, remove trailing ']'
       const spaceIndex = t.title.indexOf(' ');
       if (spaceIndex > -1) {
+        const pathToken = t.title.slice('runDartTest['.length, spaceIndex);
+        t.file = namespaceToFileName(pathToken);
         t.title = t.title.slice(spaceIndex + 1).replace(/\]$/, '');
       }
     } else {
@@ -59,7 +58,7 @@ class DartAdapter extends Adapter {
       if (params.length === 1) params[0] = 'param';
       let paramIndex = 0;
 
-      t.title = t.title.replace(/: \[(.*?)\]/g, () => {
+      t.title = t.title.replace(/\[(.*?)\]/g, () => {
         if (params.length < 2) return `\${param}`;
         const paramName = params[paramIndex] || `param${paramIndex + 1}`;
         paramIndex++;

--- a/src/junit-adapter/dart.js
+++ b/src/junit-adapter/dart.js
@@ -1,0 +1,104 @@
+import path from 'path';
+import Adapter from './adapter.js';
+
+class DartAdapter extends Adapter {
+  
+  getFilePath(t) {
+    if (t.title.includes('[')) {
+      // Android: runDartTest[tests.path.to.test Test name]
+      const fileName = namespaceToFileName(t.title.split('[')[1].split(' ')[0]);
+      return fileName;
+    }
+    // iOS: RunnerUITests tests.path.to.test Test name
+    const parts = t.title.split(' ');
+    const pathToken = parts.length > 1 ? parts[1] : parts[0];
+    return namespaceToFileName(pathToken);
+  }
+
+  formatTest(t) {
+    // Save original title for file path resolution before any transformations
+    t.originalTitle = t.title;
+
+    if (t.title.includes('[')) {
+      // Android: runDartTest[<path> <name>]
+      // First space is between the path and the test name; strip up to and including it, remove trailing ']'
+      const spaceIndex = t.title.indexOf(' ');
+      if (spaceIndex > -1) {
+        t.title = t.title.slice(spaceIndex + 1).replace(/\]$/, '');
+      }
+    } else {
+      // iOS: <ClassName> <test.path> <test name>
+      // Skip both the classname token and the dot-separated test path token
+      const parts = t.title.split(' ');
+      if (parts.length > 2 && parts[1] && parts[1].includes('.')) {
+        t.file = namespaceToFileName(parts[1]);
+        t.title = parts.slice(2).join(' ');
+      } else {
+        const spaceIndex = t.title.indexOf(' ');
+        if (spaceIndex > -1) {
+          t.title = t.title.slice(spaceIndex + 1);
+        }
+      }
+    }
+
+    // classname: cut everything after the last dot (inclusive)
+    if (t.suite_title && t.suite_title.includes('.')) {
+      const lastDot = t.suite_title.lastIndexOf('.');
+      t.suite_title = t.suite_title.slice(0, lastDot);
+    }
+
+    if (!t.file) {
+      t.file = namespaceToFileName(t.suite_title || '');
+    }
+
+    // detect params
+    const paramMatches = t.title.match(/\[(.*?)\]/g);
+
+    if (paramMatches) {
+      const params = paramMatches.map((_match, index) => `param${index + 1}`);
+      if (params.length === 1) params[0] = 'param';
+      let paramIndex = 0;
+
+      t.title = t.title.replace(/: \[(.*?)\]/g, () => {
+        if (params.length < 2) return `\${param}`;
+        const paramName = params[paramIndex] || `param${paramIndex + 1}`;
+        paramIndex++;
+        return `\${${paramName}}`;
+      });
+      const example = {};
+      paramMatches.forEach((match, index) => {
+        example[params[index]] = match.replace(/[[\]]/g, '');
+      });
+      t.example = example;
+    }
+
+    return t;
+  }
+}
+
+function namespaceToFileName(fileName) {
+  let testName = fileName;
+
+  // If it's already an extracted test name (contains dots but no runDartTest prefix)
+  if (fileName.includes('.') && !fileName.startsWith('runDartTest')) {
+    // Take only the first part before any spaces (the actual test path)
+    testName = fileName.split(' ')[0];
+  } else {
+    // Legacy handling for full runDartTest[...] format
+    const dartMatch = fileName.match(/runDartTest\[(.+?) /);
+    if (dartMatch) {
+      testName = dartMatch[1];
+    } else {
+      const parts = fileName.split(' ');
+      if (parts.length > 1) {
+        testName = parts[1];
+      }
+    }
+  }
+
+  const fileParts = testName.split('.');
+  fileParts[fileParts.length - 1] = fileParts[fileParts.length - 1]?.replace(/\$.*/, '');
+  return `${fileParts.join(path.sep)}.dart`;
+}
+
+export default DartAdapter;

--- a/src/junit-adapter/index.js
+++ b/src/junit-adapter/index.js
@@ -5,6 +5,7 @@ import PythonAdapter from './python.js';
 import RubyAdapter from './ruby.js';
 import CSharpAdapter from './csharp.js';
 import KotlinAdapter from './kotlin.js';
+import DartAdapter from './dart.js';
 
 function AdapterFactory(lang, opts) {
   if (lang === 'java') {
@@ -24,6 +25,9 @@ function AdapterFactory(lang, opts) {
   }
   if (lang === 'kotlin') {
     return new KotlinAdapter(opts);
+  }
+  if (lang === 'dart') {
+    return new DartAdapter(opts);
   }
 
   return new Adapter(opts);

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -354,6 +354,10 @@ const fetchSourceCode = (contents, opts = {}) => {
           }
         }
       }
+    } else if (opts.lang === 'dart') {
+      // For Dart we prefer to grab the whole main() body, regardless of test title
+      const mainIndex = lines.findIndex(l => l.includes('void main()'));
+      lineIndex = mainIndex;
     } else {
       lineIndex = lines.findIndex(l => l.includes(title));
     }
@@ -371,8 +375,8 @@ const fetchSourceCode = (contents, opts = {}) => {
     for (let i = lineIndex; i < lineIndex + limit; i++) {
       if (lines[i] === undefined) continue;
 
-      // Track brace depth for C# to stop after method closes
-      if (opts.lang === 'csharp') {
+      // Track brace depth for C# and Dart to stop after method/main closes
+      if (opts.lang === 'csharp' || opts.lang === 'dart') {
         const line = lines[i];
         // Count opening and closing braces
         const openBraces = (line.match(/\{/g) || []).length;

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -355,9 +355,33 @@ const fetchSourceCode = (contents, opts = {}) => {
         }
       }
     } else if (opts.lang === 'dart') {
-      // For Dart we prefer to grab the whole main() body, regardless of test title
-      const mainIndex = lines.findIndex(l => l.includes('void main()'));
-      lineIndex = mainIndex;
+      // For Dart, locate the specific patrolTest/testWidgets block by title first —
+      // otherwise every test sharing the same main() gets the same @T comment.
+      const rawTitle = opts.title || '';
+      let dartTestTitle = '';
+
+      if (rawTitle.startsWith('runDartTest[')) {
+        // Android: runDartTest[<path> <test name>]
+        const spaceIndex = rawTitle.indexOf(' ');
+        if (spaceIndex > -1) {
+          dartTestTitle = rawTitle.slice(spaceIndex + 1).replace(/\]$/, '');
+        }
+      } else {
+        // iOS: <ClassName> <test.path> <test name>
+        const parts = rawTitle.split(' ');
+        if (parts.length > 2 && parts[1] && parts[1].includes('.')) {
+          dartTestTitle = parts.slice(2).join(' ');
+        }
+      }
+
+      let testLineIndex = -1;
+      if (dartTestTitle) {
+        testLineIndex = lines.findIndex(
+          l => (l.includes('patrolTest(') || l.includes('testWidgets(')) && l.includes(dartTestTitle),
+        );
+      }
+
+      lineIndex = testLineIndex !== -1 ? testLineIndex : lines.findIndex(l => l.includes('void main()'));
     } else {
       lineIndex = lines.findIndex(l => l.includes(title));
     }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -271,6 +271,26 @@ const fetchIdFromOutput = output => {
   return output.match(TID_FULL_PATTERN)?.[2];
 };
 
+const findDartTestLine = (lines, expectedTitle) => {
+  const testFunctions = ['patrolTest', 'testWidgets'];
+  const quotedTitles = [`'${expectedTitle}',`, `"${expectedTitle}",`, `r'${expectedTitle}',`, `r"${expectedTitle}",`];
+
+  return lines.findIndex((_line, index) => {
+    const declaration = lines
+      .slice(index, index + 5)
+      .map(line => line.trim())
+      .join(' ');
+    const functionName = testFunctions.find(name => declaration.startsWith(name));
+    if (!functionName) return false;
+
+    const argumentsList = declaration.slice(functionName.length).trimStart();
+    if (!argumentsList.startsWith('(')) return false;
+
+    const firstArgument = argumentsList.slice(1).trimStart();
+    return quotedTitles.some(title => firstArgument.startsWith(title));
+  });
+};
+
 const fetchSourceCode = (contents, opts = {}) => {
   if (!opts.title && !opts.line) return '';
 
@@ -376,12 +396,10 @@ const fetchSourceCode = (contents, opts = {}) => {
 
       let testLineIndex = -1;
       if (dartTestTitle) {
-        testLineIndex = lines.findIndex(
-          l => (l.includes('patrolTest(') || l.includes('testWidgets(')) && l.includes(dartTestTitle),
-        );
+        testLineIndex = findDartTestLine(lines, dartTestTitle);
       }
 
-      lineIndex = testLineIndex !== -1 ? testLineIndex : lines.findIndex(l => l.includes('void main()'));
+      lineIndex = testLineIndex;
     } else {
       lineIndex = lines.findIndex(l => l.includes(title));
     }

--- a/src/xmlReader.js
+++ b/src/xmlReader.js
@@ -472,6 +472,7 @@ class XmlReader {
           if (file.endsWith('.js')) this.stats.language = 'js';
           if (file.endsWith('.ts')) this.stats.language = 'ts';
           if (file.endsWith('.cs')) this.stats.language = 'csharp';
+          if (file.endsWith('.dart')) this.stats.language = 'dart';
         }
 
         if (!fs.existsSync(file)) {

--- a/tests/unit/dart_import_test.js
+++ b/tests/unit/dart_import_test.js
@@ -1,0 +1,150 @@
+import { expect } from 'chai';
+import { fetchSourceCode, fetchIdFromCode } from '../../src/utils/utils.js';
+import DartAdapter from '../../src/junit-adapter/dart.js';
+
+const sampleDartCode = `import 'package:patrol/patrol.dart';
+
+void main() {
+  patrolTest('Login test', ($) async {
+    // @T00000001
+    await $.tap(find.text('Login'));
+  });
+
+  patrolTest('Login test: [admin]', ($) async {
+    // @T00000002
+    await $.tap(find.text('Login as admin'));
+  });
+
+  testWidgets('Logout test', (tester) async {
+    // @T00000003
+    await tester.tap(find.text('Logout'));
+  });
+}`;
+
+describe('Dart Code Import Tests', function () {
+  const adapter = new DartAdapter();
+
+  describe('fetchSourceCode', () => {
+    it('finds the Android test block by title and does not leak other tests', () => {
+      const result = fetchSourceCode(sampleDartCode, {
+        title: 'runDartTest[tests.login_test Login test]',
+        lang: 'dart',
+      });
+
+      expect(result).to.include("patrolTest('Login test'");
+      expect(result).to.include('@T00000001');
+      expect(result).to.not.include('@T00000002');
+      expect(result).to.not.include('@T00000003');
+    });
+
+    it('finds the correct parameterized test block by title', () => {
+      const result = fetchSourceCode(sampleDartCode, {
+        title: 'runDartTest[tests.login_test Login test: [admin]]',
+        lang: 'dart',
+      });
+
+      expect(result).to.include("patrolTest('Login test: [admin]'");
+      expect(result).to.include('@T00000002');
+      expect(result).to.not.include('@T00000001');
+      expect(result).to.not.include('@T00000003');
+    });
+
+    it('finds the iOS test block by title', () => {
+      const result = fetchSourceCode(sampleDartCode, {
+        title: 'RunnerUITests tests.logout_test Logout test',
+        lang: 'dart',
+      });
+
+      expect(result).to.include("testWidgets('Logout test'");
+      expect(result).to.include('@T00000003');
+      expect(result).to.not.include('@T00000001');
+      expect(result).to.not.include('@T00000002');
+    });
+
+    it('falls back to main() when the test title cannot be matched', () => {
+      const result = fetchSourceCode(sampleDartCode, {
+        title: 'runDartTest[tests.unknown_test Unknown test]',
+        lang: 'dart',
+      });
+
+      expect(result).to.include('void main()');
+    });
+  });
+
+  describe('fetchIdFromCode', () => {
+    it('returns the id for the matched test block only', () => {
+      const code = fetchSourceCode(sampleDartCode, {
+        title: 'runDartTest[tests.login_test Login test]',
+        lang: 'dart',
+      });
+
+      expect(fetchIdFromCode(code, { lang: 'dart' })).to.eq('00000001');
+    });
+  });
+
+  describe('DartAdapter#getFilePath', () => {
+    it('resolves the Android file path', () => {
+      const filePath = adapter.getFilePath({ title: 'runDartTest[tests.login_test Login test]' });
+      expect(filePath.replace(/\\/g, '/')).to.eq('tests/login_test.dart');
+    });
+
+    it('resolves the iOS file path', () => {
+      const filePath = adapter.getFilePath({ title: 'RunnerUITests tests.login_test Login test' });
+      expect(filePath.replace(/\\/g, '/')).to.eq('tests/login_test.dart');
+    });
+
+    it('does not misclassify a parameterized iOS title as Android', () => {
+      const filePath = adapter.getFilePath({ title: 'RunnerUITests tests.login_test Login: [admin]' });
+      expect(filePath.replace(/\\/g, '/')).to.eq('tests/login_test.dart');
+    });
+  });
+
+  describe('DartAdapter#formatTest', () => {
+    it('formats an Android test and sets the file from the title', () => {
+      const t = adapter.formatTest({ title: 'runDartTest[tests.path.to.test Login test]', suite_title: 'tests.path.to.test' });
+
+      expect(t.title).to.eq('Login test');
+      expect(t.file.replace(/\\/g, '/')).to.eq('tests/path/to/test.dart');
+    });
+
+    it('formats a parameterized Android test without leaving stray brackets', () => {
+      const t = adapter.formatTest({ title: 'runDartTest[tests.path.to.test Login: [admin]]', suite_title: 'tests.path.to.test' });
+
+      expect(t.title).to.eq('Login: ${param}');
+      expect(t.example).to.deep.eq({ param: 'admin' });
+      expect(t.file.replace(/\\/g, '/')).to.eq('tests/path/to/test.dart');
+    });
+
+    it('does not misclassify a parameterized iOS title as Android', () => {
+      const t = adapter.formatTest({
+        title: 'RunnerUITests tests.login_test Login: [admin]',
+        suite_title: 'tests.login_test',
+      });
+
+      expect(t.title).to.eq('Login: ${param}');
+      expect(t.file.replace(/\\/g, '/')).to.eq('tests/login_test.dart');
+    });
+
+    it('handles parameterized titles without a colon before the brackets', () => {
+      const t = adapter.formatTest({ title: 'runDartTest[tests.path.to.test Login test [admin]]', suite_title: 'tests.path.to.test' });
+
+      expect(t.title).to.eq('Login test ${param}');
+      expect(t.example).to.deep.eq({ param: 'admin' });
+    });
+
+    it('handles multiple params consistently between detection and replacement', () => {
+      const t = adapter.formatTest({
+        title: 'runDartTest[tests.path.to.test Login [admin] as [root]]',
+        suite_title: 'tests.path.to.test',
+      });
+
+      expect(t.title).to.eq('Login ${param1} as ${param2}');
+      expect(t.example).to.deep.eq({ param1: 'admin', param2: 'root' });
+    });
+
+    it('does not keep a dead originalTitle property', () => {
+      const t = adapter.formatTest({ title: 'runDartTest[tests.path.to.test Login test]', suite_title: 'tests.path.to.test' });
+      expect(t.originalTitle).to.be.undefined;
+    });
+  });
+});

--- a/tests/unit/dart_import_test.js
+++ b/tests/unit/dart_import_test.js
@@ -5,20 +5,28 @@ import DartAdapter from '../../src/junit-adapter/dart.js';
 const sampleDartCode = `import 'package:patrol/patrol.dart';
 
 void main() {
-  patrolTest('Login test', ($) async {
-    // @T00000001
-    await $.tap(find.text('Login'));
-  });
-
   patrolTest('Login test: [admin]', ($) async {
     // @T00000002
     await $.tap(find.text('Login as admin'));
+  });
+
+  patrolTest('Login test', ($) async {
+    // @T00000001
+    await $.tap(find.text('Login'));
   });
 
   testWidgets('Logout test', (tester) async {
     // @T00000003
     await tester.tap(find.text('Logout'));
   });
+
+  patrolTest(
+    "Multiline test",
+    ($) async {
+      // @T00000004
+      await $.tap(find.text('Multiline'));
+    },
+  );
 }`;
 
 describe('Dart Code Import Tests', function () {
@@ -61,13 +69,26 @@ describe('Dart Code Import Tests', function () {
       expect(result).to.not.include('@T00000002');
     });
 
-    it('falls back to main() when the test title cannot be matched', () => {
+    it('finds a test whose title is on the next line', () => {
+      const result = fetchSourceCode(sampleDartCode, {
+        title: 'runDartTest[tests.multiline_test Multiline test]',
+        lang: 'dart',
+      });
+
+      expect(result).to.include('patrolTest(');
+      expect(result).to.include('"Multiline test"');
+      expect(result).to.include('@T00000004');
+      expect(result).to.not.include('@T00000003');
+    });
+
+    it('returns no code when the test title cannot be matched', () => {
       const result = fetchSourceCode(sampleDartCode, {
         title: 'runDartTest[tests.unknown_test Unknown test]',
         lang: 'dart',
       });
 
-      expect(result).to.include('void main()');
+      expect(result).to.be.undefined;
+      expect(fetchIdFromCode(result, { lang: 'dart' })).to.be.null;
     });
   });
 


### PR DESCRIPTION
Adds a Dart/Flutter JUnit adapter (`src/junit-adapter/dart.js`) used for [Patrol](https://patrol.leancode.co) (LeanCode's Flutter/Dart integration-testing framework) test suites, so `report-xml --lang=dart` can extract source code and TIDs from Dart test files.

- `getFilePath`/`formatTest`: resolves the test's source file and title from Patrol's `runDartTest[tests.path.to.test Test name]` (Android) / `RunnerUITests tests.path.to.test Test name` (iOS) title format.
- Source-code extraction (`fetchSourceCode` in `src/utils/utils.js`) resolves the enclosing `void main()` body instead of matching by test title, since Patrol tests are declared as `pTest('title', ($) async { ... })` inside `main()`, not as named functions/methods — and tracks brace depth to find where that body ends (same approach already used for the C# adapter).
- `.dart` is now recognized as a tracked file extension in `xmlReader.js`'s language detection.

No new dependencies. All 498 existing unit tests pass