### PR TITLE
Add --warn flag: exit 0 when the filter matches no tests

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -56,6 +56,7 @@ npx @testomatio/reporter start --filter "testomatio:tag-name=smoke"
 - `--kind <type>`: Specify run type: `automated`, `manual`, or `mixed`. Determines how the test run is categorized in Testomat.io.
 - `--filter <filter>`: Scope the prepared run to the tests matching the filter (same syntax as [`run --filter`](#31-filter-pipes)). The run is created with that test list but **not** executed — useful to prepare a run and launch it later on CI (see [Prepare a run, then launch it on CI](#34-prepare-a-run-then-launch-it-on-ci)).
 - `--format <format>`: Print **only the run id** to `stdout` (banner and logs go to `stderr`) so it can be captured: `RUN_ID=$(npx @testomatio/reporter start --format id)`.
+- `--warn`: Exit `0` instead of `1` when the filter matches no tests — the warning is still printed. Use in pipelines where an empty scope is a normal outcome (e.g. a PR touching no mapped files).
 
 > Previously known as: `npx start-test-run --launch` _(before 1.6.0)_
 
@@ -107,6 +108,7 @@ Alias for this command – `test`, e.g. `npx @testomatio/reporter test [options]
 - `--kind <type>`: Specify run type: `automated`, `manual`, or `mixed`. Determines how the test run is categorized in Testomat.io.
 - `--remote <profile>`: Trigger the run on a CI profile configured on the Testomat.io project (e.g. `github`, `gitlab`, `jenkins`) instead of executing tests locally. The CLI creates the run on Testomat.io, asks the backend to dispatch the named CI workflow, and exits. Equivalent to setting [`TESTOMATIO_CI_PROFILE`](./configuration.md#testomatio_ci_profile).
 - `--remote-param <kv>`: `key=value` pair forwarded to the CI profile config (e.g. `branch=develop`). Repeat the option to pass multiple params. Equivalent to setting [`TESTOMATIO_CI_PARAMS`](./configuration.md#testomatio_ci_params).
+- `--warn`: Exit `0` instead of `1` when the filter matches no tests (applies to `--filter-list` too).
 
 **Examples:**
 
@@ -389,7 +391,7 @@ Prints the IDs of the tests matching the filter **without running them**. `--for
 | `json`    | JSON array                    | `["T1","T2","S3"]`   |
 | `newline` | one ID per line               | `T1` / `T2` / `S3`   |
 
-**Exit codes:** `0` when at least one test matched, `1` when nothing matched or filter resolution failed — so CI can branch on `$?` and skip launching the runner when there is nothing to run.
+**Exit codes:** `0` when at least one test matched, `1` when nothing matched or filter resolution failed — so CI can branch on `$?` and skip launching the runner when there is nothing to run. With `--warn`, the nothing-matched case also exits `0`.
 
 ```bash
 # Feed the selection straight into a runner's grep flag

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -54,6 +54,7 @@ program
   .option('--kind <type>', 'Specify run type: automated, manual, or mixed')
   .option('--filter <filter>', 'Scope the prepared run to tests matching the filter (no execution)')
   .option('--format <format>', 'Machine-readable output: print only the run id to stdout (e.g. --format id)')
+  .option('--warn', 'Exit 0 instead of 1 when the filter matches no tests (warn only)')
   .action(async opts => {
     cleanLatestRunId();
 
@@ -69,7 +70,8 @@ program
       const tests = await client.prepareRun({ pipe, pipeOptions: optsArray.join(':') });
       if (!tests || tests.length === 0) {
         log.warn(pc.yellow('No tests found for the filter. Run not created.'));
-        process.exit(1);
+        // --warn treats an empty match as a normal outcome (e.g. a PR touching no mapped files)
+        process.exit(opts.warn ? 0 : 1);
       }
       createRunParams.configuration = {
         tests: tests.filter(id => id.startsWith('T')).map(id => id.slice(1)),
@@ -127,6 +129,7 @@ program
     (value, prev) => prev.concat([value]),
     [],
   )
+  .option('--warn', 'Exit 0 instead of 1 when the filter matches no tests (warn only)')
   .action(async (command, opts) => {
     if (opts.remote) {
       if (opts.filterList) {
@@ -162,8 +165,8 @@ program
         if (!tests || tests.length === 0) {
           log.warn( pc.yellow('No tests found.'));
           // Exit non-zero on --filter-list so scripts can detect "nothing to run"
-          // via $? and skip launching the runner.
-          if (opts.filterList) process.exit(1);
+          // via $? and skip launching the runner. --warn downgrades it to 0.
+          if (opts.filterList && !opts.warn) process.exit(1);
           return;
         }
 


### PR DESCRIPTION
## Why

`start --filter` exits `1` when the filter resolves to zero tests, and `run --filter-list` does the same. For CI pipelines that prepare a run per pull request via a coverage filter, an empty match is the *normal* outcome — most PRs touch no mapped files — yet the job goes red unless it wraps the command in log-parsing bash or an allow-failure setting.

## What

- New `--warn` option on **`start`** and **`run`**: when the filter matches no tests, print the usual warning but exit `0`.
- Defaults are unchanged — without the flag, `start` and `--filter-list` still exit `1` (kept for scripts branching on `$?`), plain `run` still exits `0`. With `--warn` all three behave identically.
- `docs/cli.md` updated: both option lists and the exit-codes paragraph.

## Verified

Smoke-tested against a coverage file with no matching diff:

| Command | without `--warn` | with `--warn` |
| --- | --- | --- |
| `start --filter coverage:…` | exit 1 | exit 0 |
| `run --filter-list coverage:…` | exit 1 | exit 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)