### PR TITLE
Report a run as pending on start

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -58,6 +58,8 @@ npx @testomatio/reporter start --filter "testomatio:tag-name=smoke"
 - `--format <format>`: Print **only the run id** to `stdout` (banner and logs go to `stderr`) so it can be captured: `RUN_ID=$(npx @testomatio/reporter start --format id)`.
 - `--warn`: Exit `0` instead of `1` when the filter matches no tests — the warning is still printed. Use in pipelines where an empty scope is a normal outcome (e.g. a PR touching no mapped files).
 
+The run is reported as **pending** right after it is created, so pipes which comment on a pull request ([GitHub](./pipes/github.md), [GitLab](./pipes/gitlab.md), [Bitbucket](./pipes/bitbucket.md)) add their report immediately — the same report as on finish, listing the tests the run was scoped to with `--filter` instead of results. It is replaced once the run is finished.
+
 > Previously known as: `npx start-test-run --launch` _(before 1.6.0)_
 
 ### 2. finish

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -294,7 +294,9 @@ TESTOMATIO={API_KEY} TESTOMATIO_TITLE="title for the report" <actual run command
 
 #### `TESTOMATIO_DESCRIPTION`
 
-Add a description to the test run. It is appended to the run description on Testomat.io (after any change-aware coverage description), shown in the HTML and Markdown reports, and added — truncated to 1024 characters — to GitHub / GitLab / Bitbucket pull request comments.
+Add a description to the test run. It is shown on Testomat.io, in the HTML and Markdown reports, and added — truncated to 1024 characters — to GitHub / GitLab / Bitbucket pull request comments. Use it to pass any extra data about the run: CI context, build number, deployed version.
+
+A generated description (currently the change-aware coverage scope) does not override it — it is added after it, separated by an empty line.
 
 Example:
 

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -87,6 +87,11 @@ program
       process.exit(1);
     }
 
+    // tests are executed later, so report the run as pending with the tests it was scoped to:
+    // pipes add their report now and replace it when the run is finished
+    const plannedTests = (client.pipeStore.preparedTestIds || []).map(id => ({ test_id: id, title: id }));
+    await client.updateRunStatus('pending', { tests: plannedTests });
+
     // stdout carries ONLY the run id so it can be captured: RUN_ID=$(reporter start)
     console.log(runId);
     process.exit(0);

--- a/src/client.js
+++ b/src/client.js
@@ -371,7 +371,7 @@ class Client {
   /**
    *
    * Updates the status of the current test run and finishes the run.
-   * @param {'passed' | 'failed' | 'skipped' | 'finished'} status - The status of the current test run.
+   * @param {'passed' | 'failed' | 'skipped' | 'finished' | 'pending'} status - The status of the current test run.
    * @param {Partial<import('../types/types.js').RunData>} [params] - Additional run params (e.g. duration).
    * Must be one of "passed", "failed", or "finished"
    * @returns {Promise<any>} - A Promise that resolves when finishes the run.

--- a/src/pipe/html.js
+++ b/src/pipe/html.js
@@ -268,7 +268,7 @@ class HtmlPipe {
       executionTime: testExecutionSumTime(aggregatedTests),
       executionDate: getCurrentDateTimeFormatted(),
       description:
-        [runParams.description || this.store.coverageDescription || this.store.description, this.description]
+        [this.description, runParams.description || this.store.coverageDescription || this.store.description]
           .filter(Boolean)
           .join('\n\n') || '',
       configuration: buildDisplayConfiguration(

--- a/src/pipe/markdown.js
+++ b/src/pipe/markdown.js
@@ -140,7 +140,7 @@ class MarkdownPipe {
       executionTime: testExecutionSumTime(aggregated),
       executionDate: getCurrentDateTimeFormatted(),
       description:
-        [runParams?.description || this.store.coverageDescription || this.store.description, this.description]
+        [this.description, runParams?.description || this.store.coverageDescription || this.store.description]
           .filter(Boolean)
           .join('\n\n') || '',
       configuration: this.configuration || this.store.configuration || runParams?.configuration || null,

--- a/src/pipe/testomatio.js
+++ b/src/pipe/testomatio.js
@@ -273,8 +273,9 @@ class TestomatioPipe {
         suites: coverageConfiguration.suites?.map(id => id.replace(/^S/, '')) || [],
       };
     }
-    // Run description: coverage-derived block (if any) with the user-provided TESTOMATIO_DESCRIPTION appended after it.
-    const description = [coverageDescription, this.description].filter(Boolean).join('\n\n') || null;
+    // Run description: the user-provided TESTOMATIO_DESCRIPTION with the coverage-derived block
+    // (if any) added after it. Neither overrides the other.
+    const description = [this.description, coverageDescription].filter(Boolean).join('\n\n') || null;
 
     // Merge caller-supplied configuration (e.g. { exploratory: true }) into runParams.configuration.
     // Caller values win on key conflict; coverage-derived tests/suites lists are preserved when not overridden.
@@ -551,6 +552,9 @@ class TestomatioPipe {
     }
 
     const { status } = params;
+
+    // a pending run was just created: nothing to update here, only other pipes report it
+    if (status === 'pending') return;
 
     let status_event;
 

--- a/src/utils/pipe_utils.js
+++ b/src/utils/pipe_utils.js
@@ -117,6 +117,7 @@ function statusEmoji(status) {
   if (status === 'passed') return '🟢';
   if (status === 'failed') return '🔴';
   if (status === 'skipped') return '🟡';
+  if (status === 'pending') return '🕐';
   return '';
 }
 

--- a/tests/unit/pipes/testomatio_pipe_test.js
+++ b/tests/unit/pipes/testomatio_pipe_test.js
@@ -490,7 +490,7 @@ describe('TestomatioPipe', () => {
       expect(receivedRequestBody.data).to.have.property('description', 'Nightly regression on staging');
     });
 
-    it('should append TESTOMATIO_DESCRIPTION after the coverage description', async () => {
+    it('should add the coverage description after TESTOMATIO_DESCRIPTION', async () => {
       process.env.TESTOMATIO_DESCRIPTION = 'User note';
       let receivedRequestBody = null;
 
@@ -530,7 +530,7 @@ describe('TestomatioPipe', () => {
       await pipe.createRun({ kind: 'automated' });
 
       expect(receivedRequestBody).to.not.be.null;
-      expect(receivedRequestBody.data.description).to.equal('Coverage scope: 1 test affected\n\nUser note');
+      expect(receivedRequestBody.data.description).to.equal('User note\n\nCoverage scope: 1 test affected');
     });
 
     it('should build ci block from env vars and pipeStore for remote launch', async () => {

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -286,6 +286,8 @@ export enum RunStatus {
   Passed = 'passed',
   Failed = 'failed',
   Finished = 'finished',
+  /** run created but not executed yet, reported by `reporter start` */
+  Pending = 'pending',
 }
 
 /** Batch upload strategy:


### PR DESCRIPTION
Two small changes, +24 −8. No changes to the GitHub / GitLab / Bitbucket pipes.

## 1. `start` reports the run as pending

`npx @testomatio/reporter start` creates a run nobody is executing yet, and pipes stayed silent until someone finished it. It now finishes that run with the `pending` status through the existing API, passing the tests the run was scoped to:

```js
const plannedTests = (client.pipeStore.preparedTestIds || []).map(id => ({ test_id: id, title: id }));
await client.updateRunStatus('pending', { tests: plannedTests });
```

`finishRun({ tests })` already feeds those into `this.tests` of every pipe, so pull request pipes render their usual report with the right test count:

```
| [![Testomat.io Report](…)](https://testomat.io) | 🕐 PENDING 🕐 |
| --- | --- |
| Tests | ✔️ **3** tests run |
| Summary | 🔴 0 failed; 🟢 0 passed; 🟡 0 skipped |
```

The comment is replaced by the real report once the run is finished.

The Testomat.io pipe returns early for a pending run — it was just created, there is nothing to update there, and the planned tests must not be sent as results.

## 2. Description order

The generated description (the coverage scope) now goes **after** the user-provided `TESTOMATIO_DESCRIPTION` instead of before it — one line each in the Testomat.io, HTML and Markdown pipes. Neither overrides the other, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)