### PR TITLE
Fix Playwright failure screenshot classification

### DIFF
--- a/src/adapter/playwright.js
+++ b/src/adapter/playwright.js
@@ -255,7 +255,8 @@ function appendStep(step, shift = 0) {
       newCategory = 'hook';
       break;
     case 'attach':
-      return null; // Skip steps with category 'attach'
+    case 'test.attach':
+      return null; // Attachments are reported as artifacts, not standalone steps
     default:
       newCategory = 'framework';
   }
@@ -286,11 +287,11 @@ function appendStep(step, shift = 0) {
     resultStep.log = truncate(String(step.log), 250);
   }
 
-  // Add artifacts from attachments
-  if (step.attachments && step.attachments.length > 0 && SCREENSHOTS_ON_STEPS) {
-    const screenshotAttachment = step.attachments.find(att =>
-      att.contentType === 'image/png' && att.name === 'screenshot'
-    );
+  // Playwright also associates automatic failure screenshots with the active
+  // hook. Only attachments created for an explicit test.step belong to a step;
+  // hook and fixture attachments remain test-level result artifacts.
+  if (step.category === 'test.step' && step.attachments?.length && SCREENSHOTS_ON_STEPS) {
+    const screenshotAttachment = step.attachments.find(isScreenshotArtifact);
     if (screenshotAttachment && screenshotAttachment.path) {
       const artifacts = { screenshot: screenshotAttachment.path };
       addArtifactsToStep(resultStep, artifacts);

--- a/tests/unit/playwright_reporter_fast_artifacts_test.js
+++ b/tests/unit/playwright_reporter_fast_artifacts_test.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import path from 'path';
 import PlaywrightReporter from '../../src/adapter/playwright.js';
 
 describe('PlaywrightReporter fast artifacts', () => {
@@ -83,4 +84,132 @@ describe('PlaywrightReporter fast artifacts', () => {
     expect(addTestRunCalls[1].data.files[0].title).to.equal('fast test with artifact');
     expect(addTestRunCalls[1].data.files[0].type).to.equal('video/webm');
   });
+
+  it('keeps automatic screenshots from hook and fixture steps as test-level artifacts', async () => {
+    const screenshotPath = path.resolve('tests/unit/data/artifacts/screenshot1.png');
+    const addTestRunCalls = [];
+    const reporter = createReporter(addTestRunCalls);
+
+    await reporter.onTestEnd(
+      createTest('automatic screenshot'),
+      createResult({
+        attachments: [createScreenshot(screenshotPath)],
+        steps: [
+          {
+            attachments: [createScreenshot(screenshotPath)],
+            category: 'hook',
+            duration: 1,
+            steps: [],
+            title: 'After Hooks',
+          },
+          {
+            attachments: [createScreenshot(screenshotPath)],
+            category: 'fixture',
+            duration: 1,
+            steps: [],
+            title: 'Worker Cleanup',
+          },
+        ],
+      }),
+    );
+
+    expect(addTestRunCalls).to.have.length(1);
+    expect(addTestRunCalls[0].data.files).to.have.length(1);
+    expect(addTestRunCalls[0].data.files[0].path).to.equal(screenshotPath);
+    expect(addTestRunCalls[0].data.files[0].title).to.equal('screenshot');
+    expect(addTestRunCalls[0].data.files[0].type).to.equal('image/png');
+    for (const step of addTestRunCalls[0].data.steps) {
+      expect(step).to.not.have.property('artifacts');
+    }
+  });
+
+  it('keeps screenshots attached to test.step as step-level artifacts', async () => {
+    const screenshotPath = path.resolve('tests/unit/data/artifacts/screenshot1.png');
+    const addTestRunCalls = [];
+    const reporter = createReporter(addTestRunCalls);
+
+    await reporter.onTestEnd(
+      createTest('step screenshot'),
+      createResult({
+        attachments: [createScreenshot(screenshotPath)],
+        steps: [
+          {
+            attachments: [createScreenshot(screenshotPath)],
+            category: 'test.step',
+            duration: 1,
+            steps: [],
+            title: 'Check page rendering',
+          },
+        ],
+      }),
+    );
+
+    expect(addTestRunCalls).to.have.length(1);
+    expect(addTestRunCalls[0].data.steps[0].artifacts).to.deep.equal([screenshotPath]);
+  });
+
+  it('does not report Playwright test.attach as a framework step', async () => {
+    const addTestRunCalls = [];
+    const reporter = createReporter(addTestRunCalls);
+
+    await reporter.onTestEnd(
+      createTest('test attachment'),
+      createResult({
+        steps: [
+          {
+            category: 'test.attach',
+            duration: 1,
+            steps: [],
+            title: 'Attach evidence',
+          },
+        ],
+      }),
+    );
+
+    expect(addTestRunCalls).to.have.length(1);
+    expect(addTestRunCalls[0].data.steps).to.equal(undefined);
+  });
 });
+
+function createReporter(addTestRunCalls) {
+  const reporter = new PlaywrightReporter();
+  reporter.client = {
+    addTestRun: async (status, data) => addTestRunCalls.push({ status, data }),
+    uploader: { isEnabled: true },
+  };
+  return reporter;
+}
+
+function createTest(title) {
+  return {
+    annotations: [],
+    expectedStatus: 'passed',
+    id: title.replace(/\s+/g, '-'),
+    location: { file: 'tests/artifacts.spec.js' },
+    parent: {
+      project: () => ({ dependencies: [], metadata: {}, name: 'chromium', use: {} }),
+      title: 'artifacts suite',
+    },
+    tags: [],
+    title,
+  };
+}
+
+function createResult({ attachments = [], steps = [] } = {}) {
+  return {
+    attachments,
+    duration: 10,
+    status: 'failed',
+    stderr: [],
+    stdout: [],
+    steps,
+  };
+}
+
+function createScreenshot(screenshotPath) {
+  return {
+    contentType: 'image/png',
+    name: 'screenshot',
+    path: screenshotPath,
+  };
+}


### PR DESCRIPTION
## Summary

  - Fix automatic Playwright failure screenshots being classified as step artifacts.
  - Keep hook and fixture screenshots as test-level artifacts.
  - Preserve step-level classification for explicit `step.attach()` screenshots.
  - Exclude Playwright `test.attach` entries from the reported steps.
  - Add regression tests for both automatic and explicit screenshot attachments.