### PR TITLE
Fix Started At timestamp in HTML repor

### DIFF
--- a/src/pipe/html.js
+++ b/src/pipe/html.js
@@ -32,6 +32,7 @@ class HtmlPipe {
     this.filenameMsg = '';
     this.tests = [];
     this.configuration = null;
+    this.startedAt = null;
 
     if (this.isHtml) {
       this.isEnabled = true;
@@ -70,6 +71,8 @@ class HtmlPipe {
   }
 
   async createRun(params = {}) {
+    this.startedAt ??= new Date();
+
     if (params?.configuration && typeof params.configuration === 'object') {
       this.configuration = { ...(this.configuration || {}), ...params.configuration };
     }
@@ -266,7 +269,7 @@ class HtmlPipe {
       parallel: runParams.isParallel || 'No parallel info',
       runUrl: this.store.runUrl || '',
       executionTime: testExecutionSumTime(aggregatedTests),
-      executionDate: getCurrentDateTimeFormatted(),
+      executionDate: getDateTimeFormatted(this.startedAt || new Date()),
       description:
         [this.description, runParams.description || this.store.coverageDescription || this.store.description]
           .filter(Boolean)
@@ -722,17 +725,17 @@ function formatDuration(duration) {
 }
 
 /**
- * Retrieves the current date and time in a formatted string.
+ * Formats a date and time for display in the report.
+ * @param {Date} date - Date and time to format.
  * @returns {string} - The formatted date and time string (e.g., "(01/01/2023 12:00:00)").
  */
-function getCurrentDateTimeFormatted() {
-  const currentDate = new Date();
-  const day = currentDate.getDate().toString().padStart(2, '0');
-  const month = (currentDate.getMonth() + 1).toString().padStart(2, '0');
-  const year = currentDate.getFullYear();
-  const hours = currentDate.getHours().toString().padStart(2, '0');
-  const minutes = currentDate.getMinutes().toString().padStart(2, '0');
-  const seconds = currentDate.getSeconds().toString().padStart(2, '0');
+function getDateTimeFormatted(date) {
+  const day = date.getDate().toString().padStart(2, '0');
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const year = date.getFullYear();
+  const hours = date.getHours().toString().padStart(2, '0');
+  const minutes = date.getMinutes().toString().padStart(2, '0');
+  const seconds = date.getSeconds().toString().padStart(2, '0');
 
   return `(${day}/${month}/${year} ${hours}:${minutes}:${seconds})`;
 }

--- a/tests/unit/pipes/html_pipe_test.js
+++ b/tests/unit/pipes/html_pipe_test.js
@@ -835,6 +835,31 @@ describe('HTML report tests', () => {
     expect(rows).to.deep.include(['shard', '2']);
   });
 
+  it('renders the time captured when the run was created as Started At', async () => {
+    process.env.TESTOMATIO_HTML_REPORT_SAVE = '1';
+    const template = path.resolve(dirname, '../../..', 'src', 'template', 'testomatio.hbs');
+    const out = path.resolve(testOutputDir, 'with-started-at.html');
+    const pipe = new HtmlPipe({}, {});
+    await pipe.createRun();
+    pipe.startedAt = new Date(2024, 0, 2, 3, 4, 5);
+
+    await pipe.createRun();
+    pipe.buildReport({
+      runParams: { status: 'passed' },
+      tests: DATA.tests.slice(0, 1),
+      outputPath: out,
+      templatePath: template,
+      warningMsg: '',
+    });
+
+    const html = fs.readFileSync(out, 'utf-8');
+    const document = new JSDOM(html).window.document;
+    const startedAtLabel = Array.from(document.querySelectorAll('.stat-label')).find(element =>
+      element.textContent.includes('Started At'),
+    );
+    expect(startedAtLabel.nextElementSibling.textContent.trim()).to.equal('(02/01/2024 03:04:05)');
+  });
+
   it('omits the Configuration section when no configuration is present', () => {
     const htmlContent = fs.readFileSync(filepath, 'utf-8');
     const dom = new JSDOM(htmlContent);


### PR DESCRIPTION
## Summary

https://github.com/testomatio/reporter/issues/903

  The HTML report previously calculated `Started At` during `finishRun()`, causing it to display the report generation time instead of the run start time.

  This change captures the timestamp on the first `createRun()` call and uses it when generating the HTML report. A regression test was added to verify the behavior.