### PR TITLE
Add --kind detect to pick the run kind from its content

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -43,6 +43,7 @@ npx @testomatio/reporter start [options]
 npx @testomatio/reporter start
 npx @testomatio/reporter start --kind manual
 npx @testomatio/reporter start --kind mixed
+npx @testomatio/reporter start --kind detect --filter "testomatio:tag-name=smoke"
 npx @testomatio/reporter start --filter "testomatio:tag-name=smoke"
 ```
 
@@ -53,7 +54,7 @@ npx @testomatio/reporter start --filter "testomatio:tag-name=smoke"
 **Options:**
 
 - `--env-file <envfile>`: Load environment variables from a specific env file. If none specified, it will look for `.env` file.
-- `--kind <type>`: Specify run type: `automated`, `manual`, or `mixed`. Determines how the test run is categorized in Testomat.io.
+- `--kind <type>`: Specify run type: `automated`, `manual`, `mixed`, or `detect`. Determines how the test run is categorized in Testomat.io. See [Detecting the run kind](#11-detecting-the-run-kind).
 - `--filter <filter>`: Scope the prepared run to the tests matching the filter (same syntax as [`run --filter`](#31-filter-pipes)). The run is created with that test list but **not** executed — useful to prepare a run and launch it later on CI (see [Prepare a run, then launch it on CI](#34-prepare-a-run-then-launch-it-on-ci)).
 - `--format <format>`: Print **only the run id** to `stdout` (banner and logs go to `stderr`) so it can be captured: `RUN_ID=$(npx @testomatio/reporter start --format id)`.
 - `--warn`: Exit `0` instead of `1` when the filter matches no tests — the warning is still printed. Use in pipelines where an empty scope is a normal outcome (e.g. a PR touching no mapped files).
@@ -63,6 +64,24 @@ The run is created as **scheduled**, not running: nothing has been executed yet.
 It is also reported as **pending** right after it is created, so pipes which comment on a pull request ([GitHub](./pipes/github.md), [GitLab](./pipes/gitlab.md), [Bitbucket](./pipes/bitbucket.md)) add their report immediately — the same report as on finish, listing how many tests the run was scoped to with `--filter` instead of results. It is replaced once the run is finished.
 
 > Previously known as: `npx start-test-run --launch` _(before 1.6.0)_
+
+#### 1.1 Detecting the run kind
+
+`--kind mixed` always produces a mixed run, even when the tests it was scoped to are all of one kind. Use `--kind detect` to let Testomat.io pick the kind from the actual content of the run:
+
+| Tests the run is scoped to | Resulting kind |
+| --- | --- |
+| only manual | `manual` |
+| only automated | `automated` |
+| both | `mixed` |
+
+```bash
+npx @testomatio/reporter start --kind detect --filter "testomatio:plan-id=abc123"
+```
+
+`detect` is resolved once, when the run is created, from the tests that `--filter` scoped it to. A run started without `--filter` has no tests to inspect yet, so it stays `mixed`.
+
+`detect` is resolved by Testomat.io, so it needs a server that knows the option. Self-hosted instances that have not been updated yet reject it — keep using `--kind mixed` there.
 
 ### 2. finish
 
@@ -111,7 +130,7 @@ Alias for this command – `test`, e.g. `npx @testomatio/reporter test [options]
 - `--filter-list <filter>`: Print the list of tests matching the filter without running them. Useful for inspecting which tests would run, or for piping IDs into another command. See [Coverage Pipe](./pipes/coverage.md#machine-readable-output-with---format) for examples.
 - `--format <format>`: Machine-readable output format for `--filter-list`. Supported values: `grep`, `json`, `newline`, `ids`. When set, the CLI banner is suppressed and informational logs go to `stderr` so `stdout` stays clean for piping.
 - `--env-file <envfile>`: Load environment variables from a specific env file.
-- `--kind <type>`: Specify run type: `automated`, `manual`, or `mixed`. Determines how the test run is categorized in Testomat.io.
+- `--kind <type>`: Specify run type: `automated`, `manual`, `mixed`, or `detect`. Determines how the test run is categorized in Testomat.io. See [Detecting the run kind](#11-detecting-the-run-kind).
 - `--remote <profile>`: Trigger the run on a CI profile configured on the Testomat.io project (e.g. `github`, `gitlab`, `jenkins`) instead of executing tests locally. The CLI creates the run on Testomat.io, asks the backend to dispatch the named CI workflow, and exits. Equivalent to setting [`TESTOMATIO_CI_PROFILE`](./configuration.md#testomatio_ci_profile).
 - `--remote-param <kv>`: `key=value` pair forwarded to the CI profile config (e.g. `branch=develop`). Repeat the option to pass multiple params. Equivalent to setting [`TESTOMATIO_CI_PARAMS`](./configuration.md#testomatio_ci_params).
 - `--warn`: Exit `0` instead of `1` when the filter matches no tests (applies to `--filter-list` too).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -79,7 +79,7 @@ It is also reported as **pending** right after it is created, so pipes which com
 npx @testomatio/reporter start --kind detect --filter "testomatio:plan-id=abc123"
 ```
 
-`detect` is resolved once, when the run is created, from the tests that `--filter` scoped it to. A run started without `--filter` has no tests to inspect yet, so it stays `mixed`.
+`detect` is resolved once, when the run is created, from the tests that `--filter` scoped it to. A run created without a scope has no tests to inspect yet, so it stays `mixed`. That makes `detect` useful with `start --filter`, which prepares the run against a list of tests; `run --filter` only narrows what the test runner executes, so a run created by [`run`](#3-run) is unscoped and stays `mixed` unless it is filtered by [coverage](./pipes/coverage.md).
 
 `detect` is resolved by Testomat.io, so it needs a server that knows the option. Self-hosted instances that have not been updated yet reject it — keep using `--kind mixed` there.
 
@@ -130,7 +130,7 @@ Alias for this command – `test`, e.g. `npx @testomatio/reporter test [options]
 - `--filter-list <filter>`: Print the list of tests matching the filter without running them. Useful for inspecting which tests would run, or for piping IDs into another command. See [Coverage Pipe](./pipes/coverage.md#machine-readable-output-with---format) for examples.
 - `--format <format>`: Machine-readable output format for `--filter-list`. Supported values: `grep`, `json`, `newline`, `ids`. When set, the CLI banner is suppressed and informational logs go to `stderr` so `stdout` stays clean for piping.
 - `--env-file <envfile>`: Load environment variables from a specific env file.
-- `--kind <type>`: Specify run type: `automated`, `manual`, `mixed`, or `detect`. Determines how the test run is categorized in Testomat.io. See [Detecting the run kind](#11-detecting-the-run-kind).
+- `--kind <type>`: Specify run type: `automated`, `manual`, `mixed`, or `detect`. Determines how the test run is categorized in Testomat.io. `detect` needs a run scoped to a list of tests to resolve from, which `run --filter` does not create — see [Detecting the run kind](#11-detecting-the-run-kind).
 - `--remote <profile>`: Trigger the run on a CI profile configured on the Testomat.io project (e.g. `github`, `gitlab`, `jenkins`) instead of executing tests locally. The CLI creates the run on Testomat.io, asks the backend to dispatch the named CI workflow, and exits. Equivalent to setting [`TESTOMATIO_CI_PROFILE`](./configuration.md#testomatio_ci_profile).
 - `--remote-param <kv>`: `key=value` pair forwarded to the CI profile config (e.g. `branch=develop`). Repeat the option to pass multiple params. Equivalent to setting [`TESTOMATIO_CI_PARAMS`](./configuration.md#testomatio_ci_params).
 - `--warn`: Exit `0` instead of `1` when the filter matches no tests (applies to `--filter-list` too).

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -51,7 +51,7 @@ program
 program
   .command('start')
   .description('Start a new run and return its ID')
-  .option('--kind <type>', 'Specify run type: automated, manual, or mixed')
+  .option('--kind <type>', 'Specify run type: automated, manual, mixed, or detect')
   .option('--filter <filter>', 'Scope the prepared run to tests matching the filter (no execution)')
   .option('--format <format>', 'Machine-readable output: print only the run id to stdout (e.g. --format id)')
   .option('--warn', 'Exit 0 instead of 1 when the filter matches no tests (warn only)')
@@ -130,7 +130,7 @@ program
   .option('--filter <filter>', 'Additional execution filter')
   .option('--filter-list <filter>', 'Get a list of all tests by filter before running')
   .option('--format <format>', 'Machine-readable output format for --filter-list (grep, json, newline, ids)')
-  .option('--kind <type>', 'Specify run type: automated, manual, or mixed')
+  .option('--kind <type>', 'Specify run type: automated, manual, mixed, or detect')
   .option('--remote <profile>', 'Trigger run on the named Testomat.io CI profile instead of executing locally')
   .option(
     '--remote-param <kv>',

--- a/testomat-api-definition.yml
+++ b/testomat-api-definition.yml
@@ -148,8 +148,11 @@ components:
           description: Whether to create a parallel run
         kind:
           type: string
-          enum: [automated, manual, mixed]
-          description: Run kind. Defaults to `automated`.
+          enum: [automated, manual, mixed, detect]
+          description: >
+            Run kind. Defaults to `automated`. `detect` is not a stored kind — the server resolves it
+            from the tests the run is scoped to: only manual tests make it `manual`, only automated
+            ones make it `automated`, a mix (or an unscoped run) stays `mixed`.
         ci:
           $ref: '#/components/schemas/CiLaunchParams'
           description: |

--- a/tests/unit/pipes/testomatio_pipe_test.js
+++ b/tests/unit/pipes/testomatio_pipe_test.js
@@ -408,6 +408,21 @@ describe('TestomatioPipe', () => {
       expect(receivedRequestBody.data).to.not.have.property('status');
     });
 
+    it('should pass a detect kind to API so the server resolves it from the scoped tests', async () => {
+      let receivedRequestBody = null;
+
+      replyToCreateRun({});
+      const originalRequest = testomatioPipe.client.request;
+      testomatioPipe.client.request = async function (config) {
+        receivedRequestBody = config;
+        return originalRequest.call(this, config);
+      };
+
+      await testomatioPipe.createRun({ kind: 'detect' });
+
+      expect(receivedRequestBody.data).to.have.property('kind', 'detect');
+    });
+
     it('should pass kind parameter to API when creating a run', async () => {
       let receivedRequestBody = null;
 

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -337,8 +337,8 @@ export interface PipeResult {
  * `TESTOMATIO_CI_PROFILE` and `TESTOMATIO_CI_OVERRIDE`.
  */
 export interface CreateRunParams {
-  /** Run kind. Defaults to `automated` server-side. */
-  kind?: 'automated' | 'manual' | 'mixed';
+  /** Run kind. Defaults to `automated` server-side. `detect` resolves to one of the other three from the scoped tests. */
+  kind?: 'automated' | 'manual' | 'mixed' | 'detect';
 
   /** Run title. */
   title?: string;


### PR DESCRIPTION
Adds `--kind detect` to `start` and `run`.

## Why

`--kind mixed` always produces a mixed run, whatever it was scoped to. A `start --kind mixed --filter "testomatio:plan-id=…"` over a plan that happens to hold only manual tests still shows up in Testomat.io as mixed.

`--kind detect` asks Testomat.io to pick instead:

| Tests the run is scoped to | Resulting kind |
| --- | --- |
| only manual | `manual` |
| only automated | `automated` |
| both | `mixed` |

```bash
npx @testomatio/reporter start --kind detect --filter "testomatio:plan-id=abc123"
```

## Why the server decides

The reporter can't make this call itself. `--filter` resolves through `/api/test_grep`, which returns bare `T…`/`S…` ids with no test state attached, and a suite id is only expanded into its tests server-side. So `detect` is passed through as the run kind and resolved once, at creation, from the tests the run was scoped to.

A run created without a scope has no tests to inspect yet and stays mixed. `start --filter` creates such a scope; `run --filter` does not (it only narrows what the test runner executes), so `detect` is documented as belonging to `start` unless the [coverage](docs/pipes/coverage.md) filter is used.

## Requires the backend change

testomatio/testomatio#9703 has to be deployed first — before it lands, `--kind detect` is rejected by the server. Documented as such in `docs/cli.md`, so self-hosted instances that are behind keep using `--kind mixed`.

## Changes

- `--kind detect` accepted by `start` and `run` (the pipe already passes `kind` through verbatim)
- `CreateRunParams.kind` and the API definition list `detect`
- `docs/cli.md` gains a *Detecting the run kind* section
- pipe test asserting `kind: 'detect'` reaches the API

Verified against a stub server: `start --kind detect` sends exactly one request, `{"api_key":"…","kind":"detect","status":"scheduled"}`.

`npm run build` and `npm run lint` are clean; 546 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
