### PR TITLE
 Fix serialized CodeceptJS step logs in run-workers mode

### DIFF
--- a/src/adapter/codecept.js
+++ b/src/adapter/codecept.js
@@ -301,7 +301,7 @@ function CodeceptReporter(config) {
   });
 
   event.dispatcher.on(event.step.started, step => {
-    const stepText = `${repeat(output.stepShift)} ${step.toCliStyled ? step.toCliStyled() : step.toString()}`;
+    const stepText = `${repeat(output.stepShift)} ${formatStepLog(step)}`;
     dataStorage.putData('log', stepText);
   });
 
@@ -367,6 +367,18 @@ function stripTagsFromTitle(title) {
 
 function repeat(num) {
   return ''.padStart(num, ' ');
+}
+
+function formatStepLog(step) {
+  if (typeof step?.toCliStyled === 'function') return step.toCliStyled();
+
+  if (typeof step?.toString === 'function' && step.toString !== Object.prototype.toString) {
+    return step.toString();
+  }
+
+  const title = step?.title || '';
+  const args = Array.isArray(step?.args) ? step.args.join(', ') : '';
+  return `${title}${args ? ` ${args}` : ''}`.trim();
 }
 
 // Helper functions for cleaner event handling

--- a/tests/adapter/codecept_comprehensive.test.js
+++ b/tests/adapter/codecept_comprehensive.test.js
@@ -329,6 +329,10 @@ describe('CodeceptJS Comprehensive Adapter Tests', function () {
       const testTitles = testEntries.map(entry => entry.testId.title);
       expect(testTitles).to.include.members(['Test that passes', 'Test that fails']);
 
+      const failedTest = testEntries.find(entry => entry.testId.title === 'Test that fails');
+      expect(failedTest.testId.stack).not.to.include('[object Object]');
+      expect(failedTest.testId.stack).to.include('I expect equal 4, 5');
+
       // Verify run events are properly captured
       const runStartEvents = debugData.filter(entry => entry.action === 'createRun');
       const runFinishEvents = debugData.filter(entry => entry.action === 'finishRun');


### PR DESCRIPTION
 ## Summary

  Fixes step formatting in the CodeceptJS adapter when tests are executed with `codeceptjs run-workers`.  https://github.com/testomatio/reporter/issues/922

  Worker processes send steps to the main process as serialized plain objects. These objects do not have CodeceptJS formatting methods, so the reporter previously called `Object.prototype.toString()` and stored `[object Object]` in test logs.