### PR TITLE
Fix resolve parameters in data-driven test titles

### DIFF
--- a/example/codecept/comprehensive_test.js
+++ b/example/codecept/comprehensive_test.js
@@ -28,6 +28,11 @@ Data(['{ "input": 2, "expected": 4 }', '{ "input": 3, "expected": 6 }', '{ "inpu
   },
 );
 
+// Data-driven test with primitive rows
+Data([1, 2, 3]).Scenario('Test with ${current} data sets', ({ I, current }) => {
+  I.expectAbove(current, 0);
+}).tag('@parameterized');
+
 // Test with multiple steps
 Scenario('Test with multiple steps', ({ I, test }) => {
   console.log('Current test:', test.title);

--- a/src/adapter/codecept.js
+++ b/src/adapter/codecept.js
@@ -34,7 +34,8 @@ const HOOK_EXECUTION_ORDER = {
 // codeceptjs workers are self-contained
 dataStorage.isFileStorage = false;
 
-const DATA_REGEXP = /[|\s]+?(\{".*\}|\[.*\])/;
+// CodeceptJS appends the serialized data row of a data-driven test to its title
+const DATA_REGEXP = / \| (\{.*\}|\[.*\]|null|"(?:\\.|[^"\\])*")((?:\s+@[a-zA-Z0-9-_]+)*)$/;
 
 if (MAJOR_VERSION < 3) {
   console.log('🔴 This reporter works with CodeceptJS 3+, please update your tests');
@@ -349,15 +350,30 @@ function stripExampleFromTitle(title) {
   const res = title.match(DATA_REGEXP);
   if (!res) return { title, example: null };
 
+  let example = null;
+  let exampleParsed = false;
   try {
-    const example = JSON.parse(res[1]);
-    title = title.replace(DATA_REGEXP, '').trim();
-    return { title, example };
+    example = JSON.parse(res[1]);
+    exampleParsed = true;
   } catch (e) {
-    // If JSON parsing fails, return title without example
-    debug('Failed to parse example JSON:', res[1], e.message);
-    return { title: title.replace(DATA_REGEXP, '').trim(), example: null };
+    try {
+      example = JSON.parse(res[1].slice(1, -1));
+      exampleParsed = true;
+    } catch (e2) {
+      debug('Failed to parse example from title:', res[1]);
+    }
   }
+
+  let baseTitle = title.slice(0, res.index).trim();
+  if (exampleParsed && baseTitle.includes('${current}')) {
+    baseTitle = baseTitle.replaceAll('${current}', formatExample(example));
+  }
+  return { title: `${baseTitle}${res[2]}`, example };
+}
+
+function formatExample(example) {
+  if (example !== null && typeof example === 'object') return JSON.stringify(example);
+  return String(example);
 }
 
 function stripTagsFromTitle(title) {

--- a/tests/adapter/codecept_comprehensive.test.js
+++ b/tests/adapter/codecept_comprehensive.test.js
@@ -56,9 +56,26 @@ describe('CodeceptJS Comprehensive Adapter Tests', function () {
       // Check if examples are captured (when available)
       dataTests.forEach(test => {
         if (test.testId.example) {
-          expect(test.testId.example).to.be.an('object');
+          // example is the parsed data row: an object, an array or a primitive
+          expect(['object', 'string', 'number', 'boolean']).to.include(typeof test.testId.example);
         }
       });
+
+      // The data row CodeceptJS appends to a title is stripped, reported as example,
+      // and resolves ${current}, so every example is reported under its own title:
+      // 'Test with ${current} data sets | {1}' -> 'Test with 1 data sets'
+      const resolvedTitles = [
+        'Test with 1 data sets @parameterized',
+        'Test with 2 data sets @parameterized',
+        'Test with 3 data sets @parameterized',
+      ];
+      resolvedTitles.forEach(expectedTitle => {
+        const entry = testEntries.find(test => test.testId.title === expectedTitle);
+        expect(entry, `title: ${expectedTitle}`).to.exist;
+        expect(entry.testId.status).to.equal('passed');
+      });
+      const resolvedTests = testEntries.filter(test => resolvedTitles.includes(test.testId.title));
+      expect(resolvedTests.map(test => test.testId.example).sort()).to.deep.equal([1, 2, 3]);
     });
 
     it('should capture test metadata and execution details', async () => {


### PR DESCRIPTION
https://github.com/testomatio/testomatio/issues/9902

## Summary

  Resolve ${current} placeholders in CodeceptJS data-driven test titles before reporting results.

  CodeceptJS appends the serialized data row to each parameterized test title:

  Number ${current} should be positive | {1}

  The reporter now resolves it to:

  Number 1 should be positive

  This allows results in UI-created runs to match their pre-created example rows, preventing duplicate passed and skipped entries. The change also preserves appended tags and supports primitive, object, array, null, and masked string examples.