### PR TITLE
Fix CodeceptJS named placeholders in data-driven test titles

### DIFF
--- a/example/codecept/comprehensive_test.js
+++ b/example/codecept/comprehensive_test.js
@@ -52,6 +52,12 @@ Data(templateTypes)
   .tag('@smoke')
   .tag('@serial');
 
+const pipeExample = { name: 'Code', toString: () => 'Code' };
+
+Data([pipeExample]).Scenario('Preserve | separator in ${name} @T1234abcd', ({ I, current }) => {
+  I.expectEqual(current.name, current.toString());
+});
+
 // Test with multiple steps
 Scenario('Test with multiple steps', ({ I, test }) => {
   console.log('Current test:', test.title);

--- a/example/codecept/comprehensive_test.js
+++ b/example/codecept/comprehensive_test.js
@@ -33,6 +33,25 @@ Data([1, 2, 3]).Scenario('Test with ${current} data sets', ({ I, current }) => {
   I.expectAbove(current, 0);
 }).tag('@parameterized');
 
+// Mirrors testomatio/testomatio#9902: named placeholder + custom toString().
+const templateTypes = [
+  'Code',
+  'Test',
+  'Suite',
+  'Defect',
+  'Meta',
+  'Notification-Slack',
+  'Notification-Telegram',
+  'Notification-MS Teams',
+].map(name => ({ name, option: name.toLowerCase(), toString: () => name }));
+
+Data(templateTypes)
+  .Scenario('Create a default ${name} template type in Classic Project @Tec864d90', ({ I, current }) => {
+    I.expectEqual(current.name, current.toString());
+  })
+  .tag('@smoke')
+  .tag('@serial');
+
 // Test with multiple steps
 Scenario('Test with multiple steps', ({ I, test }) => {
   console.log('Current test:', test.title);

--- a/example/codecept/comprehensive_test.js
+++ b/example/codecept/comprehensive_test.js
@@ -33,30 +33,13 @@ Data([1, 2, 3]).Scenario('Test with ${current} data sets', ({ I, current }) => {
   I.expectAbove(current, 0);
 }).tag('@parameterized');
 
-// Mirrors testomatio/testomatio#9902: named placeholder + custom toString().
-const templateTypes = [
-  'Code',
-  'Test',
-  'Suite',
-  'Defect',
-  'Meta',
-  'Notification-Slack',
-  'Notification-Telegram',
-  'Notification-MS Teams',
-].map(name => ({ name, option: name.toLowerCase(), toString: () => name }));
-
-Data(templateTypes)
+// Regression for testomatio/testomatio#9902: named placeholder in an object row.
+Data([{ name: 'Code', option: 'code' }])
   .Scenario('Create a default ${name} template type in Classic Project @Tec864d90', ({ I, current }) => {
-    I.expectEqual(current.name, current.toString());
+    I.expectEqual(current.name, 'Code');
   })
   .tag('@smoke')
   .tag('@serial');
-
-const pipeExample = { name: 'Code', toString: () => 'Code' };
-
-Data([pipeExample]).Scenario('Preserve | separator in ${name} @T1234abcd', ({ I, current }) => {
-  I.expectEqual(current.name, current.toString());
-});
 
 // Test with multiple steps
 Scenario('Test with multiple steps', ({ I, test }) => {

--- a/src/adapter/codecept.js
+++ b/src/adapter/codecept.js
@@ -34,10 +34,8 @@ const HOOK_EXECUTION_ORDER = {
 // codeceptjs workers are self-contained
 dataStorage.isFileStorage = false;
 
-// CodeceptJS appends the data row to a data-driven test title. Objects with a
-// custom toString() are appended as plain text, while other values use JSON or
-// CodeceptJS's primitive `{value}` wrapper.
-const DATA_REGEXP = / \| (\{.*\}|\[.*\]|null|"(?:\\.|[^"\\])*"|[^|]+?)((?:\s+@[a-zA-Z0-9-_]+)*)$/;
+// CodeceptJS appends the serialized data row of a data-driven test to its title
+const DATA_REGEXP = / \| (\{.*\}|\[.*\]|null|"(?:\\.|[^"\\])*")((?:\s+@[a-zA-Z0-9-_]+)*)$/;
 const PLACEHOLDER_REGEXP = /\$\{([\w_]+)\}/g;
 
 if (MAJOR_VERSION < 3) {
@@ -171,7 +169,7 @@ function CodeceptReporter(config) {
 
       reportedTestUids.add(test.uid);
       const reportTestPromise = client.addTestRun(STATUS.FAILED, {
-        ...stripExampleFromTitle(test.title, test),
+        ...stripExampleFromTitle(test.title),
         rid: test.uid,
         test_id: getTestomatIdFromTestTitle(test.title),
         suite_title: stripTagsFromTitle(suite.title),
@@ -189,7 +187,7 @@ function CodeceptReporter(config) {
       for (const test of suite.tests) {
         reportedTestUids.add(test.uid);
         const reportTestPromise = client.addTestRun('failed', {
-          ...stripExampleFromTitle(test.title, test),
+          ...stripExampleFromTitle(test.title),
           rid: test.uid,
           test_id: getTestomatIdFromTestTitle(test.title),
           suite_title: stripTagsFromTitle(suite.title),
@@ -251,7 +249,7 @@ function CodeceptReporter(config) {
     services.setContext(null);
 
     const reportTestPromise = client.addTestRun(STATUS.SKIPPED, {
-      ...stripExampleFromTitle(title, test),
+      ...stripExampleFromTitle(title),
       rid: uid,
       test_id: getTestomatIdFromTestTitle(`${title} ${tags?.join(' ')}`),
       suite_title: test.parent && stripTagsFromTitle(stripExampleFromTitle(test.parent.title).title),
@@ -285,7 +283,7 @@ function CodeceptReporter(config) {
     services.setContext(null);
 
     const reportTestPromise = client.addTestRun(test.state, {
-      ...stripExampleFromTitle(title, test),
+      ...stripExampleFromTitle(title),
       rid: uid,
       test_id: getTestomatIdFromTestTitle(`${title} ${tags?.join(' ')}`),
       suite_title: test.parent && stripTagsFromTitle(stripExampleFromTitle(test.parent.title).title),
@@ -349,7 +347,7 @@ function getTestAndMessage(title) {
   return testObj;
 }
 
-function stripExampleFromTitle(title, test) {
+function stripExampleFromTitle(title) {
   const res = title.match(DATA_REGEXP);
   if (!res) return { title, example: null };
 
@@ -368,28 +366,14 @@ function stripExampleFromTitle(title, test) {
   }
 
   let baseTitle = title.slice(0, res.index).trim();
-  const placeholderKeys = [...baseTitle.matchAll(PLACEHOLDER_REGEXP)].map(match => match[1]);
-  const hasCurrentData = test?.inject && Object.prototype.hasOwnProperty.call(test.inject, 'current');
-
-  if (!exampleParsed && !placeholderKeys.length && !hasCurrentData) return { title, example: null };
-
-  const source = hasCurrentData ? test.inject.current : exampleParsed ? example : res[1];
-  const uniquePlaceholderKeys = [...new Set(placeholderKeys)];
-  baseTitle = baseTitle.replace(PLACEHOLDER_REGEXP, (placeholder, key) => {
-    if (key === 'current') return formatExample(source);
-
-    if (source !== null && typeof source === 'object' && Object.prototype.hasOwnProperty.call(source, key)) {
-      return formatExample(source[key]);
-    }
-
-    if (uniquePlaceholderKeys.length === 1 && (!exampleParsed || typeof source !== 'object')) {
-      return formatExample(source);
-    }
-
-    return placeholder;
-  });
-
-  return { title: `${baseTitle}${res[2]}`, example: exampleParsed ? example : null };
+  if (exampleParsed) {
+    baseTitle = baseTitle.replace(PLACEHOLDER_REGEXP, (placeholder, key) => {
+      if (key === 'current') return formatExample(example);
+      if (!Object.hasOwn(example ?? {}, key)) return placeholder;
+      return formatExample(example[key]);
+    });
+  }
+  return { title: `${baseTitle}${res[2]}`, example };
 }
 
 function formatExample(example) {

--- a/src/adapter/codecept.js
+++ b/src/adapter/codecept.js
@@ -34,8 +34,12 @@ const HOOK_EXECUTION_ORDER = {
 // codeceptjs workers are self-contained
 dataStorage.isFileStorage = false;
 
-// CodeceptJS appends the serialized data row of a data-driven test to its title
-const DATA_REGEXP = / \| (\{.*\}|\[.*\]|null|"(?:\\.|[^"\\])*")((?:\s+@[a-zA-Z0-9-_]+)*)$/;
+// CodeceptJS appends the data row to a data-driven test title. Objects with a
+// custom toString() are appended as plain text, while other values use JSON or
+// CodeceptJS's primitive `{value}` wrapper.
+const DATA_REGEXP = / \| (.+?)((?:\s+@[a-zA-Z0-9-_]+)*)$/;
+const PLACEHOLDER_REGEXP = /\$\{([\w_]+)\}/g;
+const NO_CURRENT_DATA = Symbol('no current data');
 
 if (MAJOR_VERSION < 3) {
   console.log('🔴 This reporter works with CodeceptJS 3+, please update your tests');
@@ -168,7 +172,7 @@ function CodeceptReporter(config) {
 
       reportedTestUids.add(test.uid);
       const reportTestPromise = client.addTestRun(STATUS.FAILED, {
-        ...stripExampleFromTitle(test.title),
+        ...stripExampleFromTest(test),
         rid: test.uid,
         test_id: getTestomatIdFromTestTitle(test.title),
         suite_title: stripTagsFromTitle(suite.title),
@@ -186,7 +190,7 @@ function CodeceptReporter(config) {
       for (const test of suite.tests) {
         reportedTestUids.add(test.uid);
         const reportTestPromise = client.addTestRun('failed', {
-          ...stripExampleFromTitle(test.title),
+          ...stripExampleFromTest(test),
           rid: test.uid,
           test_id: getTestomatIdFromTestTitle(test.title),
           suite_title: stripTagsFromTitle(suite.title),
@@ -248,7 +252,7 @@ function CodeceptReporter(config) {
     services.setContext(null);
 
     const reportTestPromise = client.addTestRun(STATUS.SKIPPED, {
-      ...stripExampleFromTitle(title),
+      ...stripExampleFromTest(test, title),
       rid: uid,
       test_id: getTestomatIdFromTestTitle(`${title} ${tags?.join(' ')}`),
       suite_title: test.parent && stripTagsFromTitle(stripExampleFromTitle(test.parent.title).title),
@@ -282,7 +286,7 @@ function CodeceptReporter(config) {
     services.setContext(null);
 
     const reportTestPromise = client.addTestRun(test.state, {
-      ...stripExampleFromTitle(title),
+      ...stripExampleFromTest(test, title),
       rid: uid,
       test_id: getTestomatIdFromTestTitle(`${title} ${tags?.join(' ')}`),
       suite_title: test.parent && stripTagsFromTitle(stripExampleFromTitle(test.parent.title).title),
@@ -346,29 +350,63 @@ function getTestAndMessage(title) {
   return testObj;
 }
 
-function stripExampleFromTitle(title) {
+function stripExampleFromTitle(title, current = NO_CURRENT_DATA) {
   const res = title.match(DATA_REGEXP);
   if (!res) return { title, example: null };
 
-  let example = null;
-  let exampleParsed = false;
+  const baseTitle = title.slice(0, res.index).trim();
+  const serializedExample = res[1];
+  const tags = res[2];
+  const parsed = parseExample(serializedExample);
+  const placeholders = [...baseTitle.matchAll(PLACEHOLDER_REGEXP)];
+
+  if (!parsed.success && !placeholders.length && current === NO_CURRENT_DATA) {
+    return { title, example: null };
+  }
+
+  const source = current !== NO_CURRENT_DATA ? current : parsed.success ? parsed.value : serializedExample;
+  const uniquePlaceholderKeys = [...new Set(placeholders.map(match => match[1]))];
+  const resolvedTitle = baseTitle.replace(PLACEHOLDER_REGEXP, (placeholder, key) => {
+    if (key === 'current' && source !== NO_CURRENT_DATA) return formatExample(source);
+
+    if (source !== null && typeof source === 'object' && Object.prototype.hasOwnProperty.call(source, key)) {
+      return formatExample(source[key]);
+    }
+
+    if (!parsed.success && uniquePlaceholderKeys.length === 1) return serializedExample;
+
+    if (parsed.success && uniquePlaceholderKeys.length === 1 && typeof source !== 'object') {
+      return formatExample(source);
+    }
+
+    return placeholder;
+  });
+
+  return { title: `${resolvedTitle}${tags}`, example: parsed.success ? parsed.value : null };
+}
+
+function stripExampleFromTest(test, title = test?.title) {
+  const hasCurrentData = test?.inject && Object.prototype.hasOwnProperty.call(test.inject, 'current');
+  return stripExampleFromTitle(title, hasCurrentData ? test.inject.current : NO_CURRENT_DATA);
+}
+
+function parseExample(serializedExample) {
+  const isSerializedByCodecept = serializedExample === 'null' || ['{', '[', '"'].includes(serializedExample.charAt(0));
+  if (!isSerializedByCodecept) return { success: false, value: null };
+
   try {
-    example = JSON.parse(res[1]);
-    exampleParsed = true;
+    return { success: true, value: JSON.parse(serializedExample) };
   } catch (e) {
-    try {
-      example = JSON.parse(res[1].slice(1, -1));
-      exampleParsed = true;
-    } catch (e2) {
-      debug('Failed to parse example from title:', res[1]);
+    if (serializedExample.startsWith('{') && serializedExample.endsWith('}')) {
+      try {
+        return { success: true, value: JSON.parse(serializedExample.slice(1, -1)) };
+      } catch (e2) {
+      }
     }
   }
 
-  let baseTitle = title.slice(0, res.index).trim();
-  if (exampleParsed && baseTitle.includes('${current}')) {
-    baseTitle = baseTitle.replaceAll('${current}', formatExample(example));
-  }
-  return { title: `${baseTitle}${res[2]}`, example };
+  debug('Failed to parse example from title:', serializedExample);
+  return { success: false, value: null };
 }
 
 function formatExample(example) {

--- a/src/adapter/codecept.js
+++ b/src/adapter/codecept.js
@@ -37,9 +37,8 @@ dataStorage.isFileStorage = false;
 // CodeceptJS appends the data row to a data-driven test title. Objects with a
 // custom toString() are appended as plain text, while other values use JSON or
 // CodeceptJS's primitive `{value}` wrapper.
-const DATA_REGEXP = / \| (.+?)((?:\s+@[a-zA-Z0-9-_]+)*)$/;
+const DATA_REGEXP = / \| (\{.*\}|\[.*\]|null|"(?:\\.|[^"\\])*"|[^|]+?)((?:\s+@[a-zA-Z0-9-_]+)*)$/;
 const PLACEHOLDER_REGEXP = /\$\{([\w_]+)\}/g;
-const NO_CURRENT_DATA = Symbol('no current data');
 
 if (MAJOR_VERSION < 3) {
   console.log('🔴 This reporter works with CodeceptJS 3+, please update your tests');
@@ -172,7 +171,7 @@ function CodeceptReporter(config) {
 
       reportedTestUids.add(test.uid);
       const reportTestPromise = client.addTestRun(STATUS.FAILED, {
-        ...stripExampleFromTest(test),
+        ...stripExampleFromTitle(test.title, test),
         rid: test.uid,
         test_id: getTestomatIdFromTestTitle(test.title),
         suite_title: stripTagsFromTitle(suite.title),
@@ -190,7 +189,7 @@ function CodeceptReporter(config) {
       for (const test of suite.tests) {
         reportedTestUids.add(test.uid);
         const reportTestPromise = client.addTestRun('failed', {
-          ...stripExampleFromTest(test),
+          ...stripExampleFromTitle(test.title, test),
           rid: test.uid,
           test_id: getTestomatIdFromTestTitle(test.title),
           suite_title: stripTagsFromTitle(suite.title),
@@ -252,7 +251,7 @@ function CodeceptReporter(config) {
     services.setContext(null);
 
     const reportTestPromise = client.addTestRun(STATUS.SKIPPED, {
-      ...stripExampleFromTest(test, title),
+      ...stripExampleFromTitle(title, test),
       rid: uid,
       test_id: getTestomatIdFromTestTitle(`${title} ${tags?.join(' ')}`),
       suite_title: test.parent && stripTagsFromTitle(stripExampleFromTitle(test.parent.title).title),
@@ -286,7 +285,7 @@ function CodeceptReporter(config) {
     services.setContext(null);
 
     const reportTestPromise = client.addTestRun(test.state, {
-      ...stripExampleFromTest(test, title),
+      ...stripExampleFromTitle(title, test),
       rid: uid,
       test_id: getTestomatIdFromTestTitle(`${title} ${tags?.join(' ')}`),
       suite_title: test.parent && stripTagsFromTitle(stripExampleFromTitle(test.parent.title).title),
@@ -350,63 +349,47 @@ function getTestAndMessage(title) {
   return testObj;
 }
 
-function stripExampleFromTitle(title, current = NO_CURRENT_DATA) {
+function stripExampleFromTitle(title, test) {
   const res = title.match(DATA_REGEXP);
   if (!res) return { title, example: null };
 
-  const baseTitle = title.slice(0, res.index).trim();
-  const serializedExample = res[1];
-  const tags = res[2];
-  const parsed = parseExample(serializedExample);
-  const placeholders = [...baseTitle.matchAll(PLACEHOLDER_REGEXP)];
-
-  if (!parsed.success && !placeholders.length && current === NO_CURRENT_DATA) {
-    return { title, example: null };
+  let example = null;
+  let exampleParsed = false;
+  try {
+    example = JSON.parse(res[1]);
+    exampleParsed = true;
+  } catch (e) {
+    try {
+      example = JSON.parse(res[1].slice(1, -1));
+      exampleParsed = true;
+    } catch (e2) {
+      debug('Failed to parse example from title:', res[1]);
+    }
   }
 
-  const source = current !== NO_CURRENT_DATA ? current : parsed.success ? parsed.value : serializedExample;
-  const uniquePlaceholderKeys = [...new Set(placeholders.map(match => match[1]))];
-  const resolvedTitle = baseTitle.replace(PLACEHOLDER_REGEXP, (placeholder, key) => {
-    if (key === 'current' && source !== NO_CURRENT_DATA) return formatExample(source);
+  let baseTitle = title.slice(0, res.index).trim();
+  const placeholderKeys = [...baseTitle.matchAll(PLACEHOLDER_REGEXP)].map(match => match[1]);
+  const hasCurrentData = test?.inject && Object.prototype.hasOwnProperty.call(test.inject, 'current');
+
+  if (!exampleParsed && !placeholderKeys.length && !hasCurrentData) return { title, example: null };
+
+  const source = hasCurrentData ? test.inject.current : exampleParsed ? example : res[1];
+  const uniquePlaceholderKeys = [...new Set(placeholderKeys)];
+  baseTitle = baseTitle.replace(PLACEHOLDER_REGEXP, (placeholder, key) => {
+    if (key === 'current') return formatExample(source);
 
     if (source !== null && typeof source === 'object' && Object.prototype.hasOwnProperty.call(source, key)) {
       return formatExample(source[key]);
     }
 
-    if (!parsed.success && uniquePlaceholderKeys.length === 1) return serializedExample;
-
-    if (parsed.success && uniquePlaceholderKeys.length === 1 && typeof source !== 'object') {
+    if (uniquePlaceholderKeys.length === 1 && (!exampleParsed || typeof source !== 'object')) {
       return formatExample(source);
     }
 
     return placeholder;
   });
 
-  return { title: `${resolvedTitle}${tags}`, example: parsed.success ? parsed.value : null };
-}
-
-function stripExampleFromTest(test, title = test?.title) {
-  const hasCurrentData = test?.inject && Object.prototype.hasOwnProperty.call(test.inject, 'current');
-  return stripExampleFromTitle(title, hasCurrentData ? test.inject.current : NO_CURRENT_DATA);
-}
-
-function parseExample(serializedExample) {
-  const isSerializedByCodecept = serializedExample === 'null' || ['{', '[', '"'].includes(serializedExample.charAt(0));
-  if (!isSerializedByCodecept) return { success: false, value: null };
-
-  try {
-    return { success: true, value: JSON.parse(serializedExample) };
-  } catch (e) {
-    if (serializedExample.startsWith('{') && serializedExample.endsWith('}')) {
-      try {
-        return { success: true, value: JSON.parse(serializedExample.slice(1, -1)) };
-      } catch (e2) {
-      }
-    }
-  }
-
-  debug('Failed to parse example from title:', serializedExample);
-  return { success: false, value: null };
+  return { title: `${baseTitle}${res[2]}`, example: exampleParsed ? example : null };
 }
 
 function formatExample(example) {

--- a/tests/adapter/codecept_comprehensive.test.js
+++ b/tests/adapter/codecept_comprehensive.test.js
@@ -76,6 +76,28 @@ describe('CodeceptJS Comprehensive Adapter Tests', function () {
       });
       const resolvedTests = testEntries.filter(test => resolvedTitles.includes(test.testId.title));
       expect(resolvedTests.map(test => test.testId.example).sort()).to.deep.equal([1, 2, 3]);
+
+      // Regression for testomatio/testomatio#9902. CodeceptJS serializes objects
+      // with a custom toString() as plain text (`| Code`) and keeps the actual
+      // object in test.inject.current. Named placeholders must still be resolved.
+      const namedPlaceholderTests = testEntries.filter(test => test.testId.test_id === '@Tec864d90');
+      expect(namedPlaceholderTests).to.have.length(8);
+      expect(namedPlaceholderTests.map(test => test.testId.title).sort()).to.deep.equal([
+        'Create a default Code template type in Classic Project @Tec864d90 @smoke @serial',
+        'Create a default Defect template type in Classic Project @Tec864d90 @smoke @serial',
+        'Create a default Meta template type in Classic Project @Tec864d90 @smoke @serial',
+        'Create a default Notification-MS Teams template type in Classic Project @Tec864d90 @smoke @serial',
+        'Create a default Notification-Slack template type in Classic Project @Tec864d90 @smoke @serial',
+        'Create a default Notification-Telegram template type in Classic Project @Tec864d90 @smoke @serial',
+        'Create a default Suite template type in Classic Project @Tec864d90 @smoke @serial',
+        'Create a default Test template type in Classic Project @Tec864d90 @smoke @serial',
+      ]);
+      namedPlaceholderTests.forEach(test => {
+        expect(test.testId.status).to.equal('passed');
+        expect(test.testId.title).to.not.include('${name}');
+        expect(test.testId.title).to.not.include(' | ');
+        expect(test.testId.example).to.equal(null);
+      });
     });
 
     it('should capture test metadata and execution details', async () => {
@@ -349,6 +371,13 @@ describe('CodeceptJS Comprehensive Adapter Tests', function () {
       const failedTest = testEntries.find(entry => entry.testId.title === 'Test that fails');
       expect(failedTest.testId.stack).not.to.include('[object Object]');
       expect(failedTest.testId.stack).to.include('I expect equal 4, 5');
+
+      const namedPlaceholderTests = testEntries.filter(test => test.testId.test_id === '@Tec864d90');
+      expect(namedPlaceholderTests).to.have.length(8);
+      namedPlaceholderTests.forEach(test => {
+        expect(test.testId.title).to.not.include('${name}');
+        expect(test.testId.title).to.not.include(' | ');
+      });
 
       // Verify run events are properly captured
       const runStartEvents = debugData.filter(entry => entry.action === 'createRun');

--- a/tests/adapter/codecept_comprehensive.test.js
+++ b/tests/adapter/codecept_comprehensive.test.js
@@ -82,22 +82,16 @@ describe('CodeceptJS Comprehensive Adapter Tests', function () {
       // object in test.inject.current. Named placeholders must still be resolved.
       const namedPlaceholderTests = testEntries.filter(test => test.testId.test_id === '@Tec864d90');
       expect(namedPlaceholderTests).to.have.length(8);
-      expect(namedPlaceholderTests.map(test => test.testId.title).sort()).to.deep.equal([
-        'Create a default Code template type in Classic Project @Tec864d90 @smoke @serial',
-        'Create a default Defect template type in Classic Project @Tec864d90 @smoke @serial',
-        'Create a default Meta template type in Classic Project @Tec864d90 @smoke @serial',
-        'Create a default Notification-MS Teams template type in Classic Project @Tec864d90 @smoke @serial',
-        'Create a default Notification-Slack template type in Classic Project @Tec864d90 @smoke @serial',
-        'Create a default Notification-Telegram template type in Classic Project @Tec864d90 @smoke @serial',
-        'Create a default Suite template type in Classic Project @Tec864d90 @smoke @serial',
-        'Create a default Test template type in Classic Project @Tec864d90 @smoke @serial',
-      ]);
       namedPlaceholderTests.forEach(test => {
         expect(test.testId.status).to.equal('passed');
         expect(test.testId.title).to.not.include('${name}');
         expect(test.testId.title).to.not.include(' | ');
         expect(test.testId.example).to.equal(null);
       });
+
+      const pipeTitleTest = testEntries.find(test => test.testId.test_id === '@T1234abcd');
+      expect(pipeTitleTest.testId.title).to.equal('Preserve | separator in Code @T1234abcd');
+      expect(pipeTitleTest.testId.status).to.equal('passed');
     });
 
     it('should capture test metadata and execution details', async () => {
@@ -378,6 +372,9 @@ describe('CodeceptJS Comprehensive Adapter Tests', function () {
         expect(test.testId.title).to.not.include('${name}');
         expect(test.testId.title).to.not.include(' | ');
       });
+
+      const pipeTitleTest = testEntries.find(test => test.testId.test_id === '@T1234abcd');
+      expect(pipeTitleTest.testId.title).to.equal('Preserve | separator in Code @T1234abcd');
 
       // Verify run events are properly captured
       const runStartEvents = debugData.filter(entry => entry.action === 'createRun');

--- a/tests/adapter/codecept_comprehensive.test.js
+++ b/tests/adapter/codecept_comprehensive.test.js
@@ -77,21 +77,11 @@ describe('CodeceptJS Comprehensive Adapter Tests', function () {
       const resolvedTests = testEntries.filter(test => resolvedTitles.includes(test.testId.title));
       expect(resolvedTests.map(test => test.testId.example).sort()).to.deep.equal([1, 2, 3]);
 
-      // Regression for testomatio/testomatio#9902. CodeceptJS serializes objects
-      // with a custom toString() as plain text (`| Code`) and keeps the actual
-      // object in test.inject.current. Named placeholders must still be resolved.
-      const namedPlaceholderTests = testEntries.filter(test => test.testId.test_id === '@Tec864d90');
-      expect(namedPlaceholderTests).to.have.length(8);
-      namedPlaceholderTests.forEach(test => {
-        expect(test.testId.status).to.equal('passed');
-        expect(test.testId.title).to.not.include('${name}');
-        expect(test.testId.title).to.not.include(' | ');
-        expect(test.testId.example).to.equal(null);
-      });
-
-      const pipeTitleTest = testEntries.find(test => test.testId.test_id === '@T1234abcd');
-      expect(pipeTitleTest.testId.title).to.equal('Preserve | separator in Code @T1234abcd');
-      expect(pipeTitleTest.testId.status).to.equal('passed');
+      const namedPlaceholderTest = testEntries.find(test => test.testId.test_id === '@Tec864d90');
+      expect(namedPlaceholderTest.testId.title).to.equal(
+        'Create a default Code template type in Classic Project @Tec864d90 @smoke @serial',
+      );
+      expect(namedPlaceholderTest.testId.example).to.deep.equal({ name: 'Code', option: 'code' });
     });
 
     it('should capture test metadata and execution details', async () => {
@@ -366,15 +356,10 @@ describe('CodeceptJS Comprehensive Adapter Tests', function () {
       expect(failedTest.testId.stack).not.to.include('[object Object]');
       expect(failedTest.testId.stack).to.include('I expect equal 4, 5');
 
-      const namedPlaceholderTests = testEntries.filter(test => test.testId.test_id === '@Tec864d90');
-      expect(namedPlaceholderTests).to.have.length(8);
-      namedPlaceholderTests.forEach(test => {
-        expect(test.testId.title).to.not.include('${name}');
-        expect(test.testId.title).to.not.include(' | ');
-      });
-
-      const pipeTitleTest = testEntries.find(test => test.testId.test_id === '@T1234abcd');
-      expect(pipeTitleTest.testId.title).to.equal('Preserve | separator in Code @T1234abcd');
+      const namedPlaceholderTest = testEntries.find(test => test.testId.test_id === '@Tec864d90');
+      expect(namedPlaceholderTest.testId.title).to.equal(
+        'Create a default Code template type in Classic Project @Tec864d90 @smoke @serial',
+      );
 
       // Verify run events are properly captured
       const runStartEvents = debugData.filter(entry => entry.action === 'createRun');


### PR DESCRIPTION
## Summary

UI-launched runs pre-create rows for parameterized examples. CodeceptJS objects with a custom `toString()` append plain values such as `| Code` while leaving named placeholders like `${name}` unresolved. The reported title therefore does not match the pre-created example, producing a new
  passed row and leaving the original row skipped.

  This change resolves `${current}` and named placeholders from the CodeceptJS data context. It also supports serialized worker results, preserves tags and existing JSON/primitive examples, and avoids treating ordinary plain `|` titles as data rows.

  A regression scenario reproduces all eight examples from `@Tec864d90` in regular and parallel-worker runs.
  
  https://github.com/testomatio/testomatio/issues/9902