### PR TITLE
Fix CodeceptJS data-driven test titles and examples

### DIFF
--- a/example/codecept/comprehensive_test.js
+++ b/example/codecept/comprehensive_test.js
@@ -41,6 +41,16 @@ Data([{ name: 'Code', option: 'code' }])
   .tag('@smoke')
   .tag('@serial');
 
+// Object rows whose key is used as the title placeholder report only that key's value
+Data([
+  { current: 1, param2: 'A' },
+  { current: 2, param2: 'B' },
+])
+  .Scenario('Number ${current} should be positive @T61faa1d4', ({ I, current }) => {
+    I.expectAbove(current.current, 0);
+  })
+  .tag('@parameterized');
+
 // Test with multiple steps
 Scenario('Test with multiple steps', ({ I, test }) => {
   console.log('Current test:', test.title);

--- a/src/adapter/codecept.js
+++ b/src/adapter/codecept.js
@@ -367,13 +367,28 @@ function stripExampleFromTitle(title) {
 
   let baseTitle = title.slice(0, res.index).trim();
   if (exampleParsed) {
+    const placeholderKeys = [...new Set([...baseTitle.matchAll(PLACEHOLDER_REGEXP)].map(match => match[1]))];
     baseTitle = baseTitle.replace(PLACEHOLDER_REGEXP, (placeholder, key) => {
+      // a placeholder matching a key of an object row resolves to that key's value
+      if (Object.hasOwn(example ?? {}, key)) return formatExample(example[key]);
       if (key === 'current') return formatExample(example);
-      if (!Object.hasOwn(example ?? {}, key)) return placeholder;
-      return formatExample(example[key]);
+      return placeholder;
     });
+    example = reduceExample(example, placeholderKeys);
   }
   return { title: `${baseTitle}${res[2]}`, example };
+}
+
+// When the title uses only some keys of an object row, report just those values,
+// the way Playwright shows only the parameters referenced in the title
+function reduceExample(example, placeholderKeys) {
+  if (example === null || typeof example !== 'object' || Array.isArray(example)) return example;
+
+  const usedKeys = placeholderKeys.filter(key => Object.hasOwn(example, key));
+  if (!usedKeys.length) return example;
+  if (usedKeys.length === 1) return example[usedKeys[0]];
+
+  return Object.fromEntries(usedKeys.map(key => [key, example[key]]));
 }
 
 function formatExample(example) {

--- a/tests/adapter/codecept_comprehensive.test.js
+++ b/tests/adapter/codecept_comprehensive.test.js
@@ -81,7 +81,18 @@ describe('CodeceptJS Comprehensive Adapter Tests', function () {
       expect(namedPlaceholderTest.testId.title).to.equal(
         'Create a default Code template type in Classic Project @Tec864d90 @smoke @serial',
       );
-      expect(namedPlaceholderTest.testId.example).to.deep.equal({ name: 'Code', option: 'code' });
+      expect(namedPlaceholderTest.testId.example).to.equal('Code');
+
+      // A placeholder matching a key of an object row resolves to that key's value only,
+      // so the title is resolved and the example reports just the used value:
+      // 'Number ${current} should be positive | {"current":1,"param2":"A"}'
+      //   -> 'Number 1 should be positive' with example 1
+      const keyedPlaceholderTests = testEntries.filter(test => test.testId.test_id === '@T61faa1d4');
+      expect(keyedPlaceholderTests.map(test => test.testId.title)).to.deep.equal([
+        'Number 1 should be positive @T61faa1d4 @parameterized',
+        'Number 2 should be positive @T61faa1d4 @parameterized',
+      ]);
+      expect(keyedPlaceholderTests.map(test => test.testId.example)).to.deep.equal([1, 2]);
     });
 
     it('should capture test metadata and execution details', async () => {


### PR DESCRIPTION
## Summary 

Resolves `${placeholder}` in CodeceptJS data-driven test titles and cleans up the reported examples

https://github.com/testomatio/testomatio/issues/9902